### PR TITLE
Fix the awaitable collect() calls.

### DIFF
--- a/lib/counter.js
+++ b/lib/counter.js
@@ -109,7 +109,7 @@ class Counter extends Metric {
 	async get() {
 		if (this.collect) {
 			const v = this.collect();
-			if (v instanceof Promise) await v;
+			if ((v instanceof Promise) || (v.then instanceof Function)) await v;
 		}
 
 		return {

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -108,7 +108,7 @@ class Gauge extends Metric {
 	async get() {
 		if (this.collect) {
 			const v = this.collect();
-			if (v instanceof Promise) await v;
+			if ((v instanceof Promise) || (v.then instanceof Function)) await v;
 		}
 		return {
 			help: this.help,

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -108,7 +108,7 @@ class Histogram extends Metric {
 	async getForPromString() {
 		if (this.collect) {
 			const v = this.collect();
-			if (v instanceof Promise) await v;
+			if ((v instanceof Promise) || (v.then instanceof Function)) await v;
 		}
 		const data = Object.values(this.hashMap);
 		const values = data

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -51,7 +51,7 @@ class Summary extends Metric {
 	async get() {
 		if (this.collect) {
 			const v = this.collect();
-			if (v instanceof Promise) await v;
+			if ((v instanceof Promise) || (v.then instanceof Function)) await v;
 		}
 		const hashKeys = Object.keys(this.hashMap);
 		const values = [];


### PR DESCRIPTION
In case if non-native promises are used, the Promise object won't be instanceof Promise. That's still valid in JS, as Promise is something that implements then(). It's always safe to cast a maybe-promise into native Promise with Promise.resolve().