### PR TITLE
fix: Add missing properties to metrics types from abstract class Metric

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -182,6 +182,38 @@ export type Metric<T extends string = NoLabelNameType> =
 	| Summary<T>
 	| Histogram<T>;
 
+declare abstract class AbstractMetric {
+	/**
+	 * The name of the metric.
+	 */
+	readonly name: string;
+
+	/**
+	 * The help text of the metric.
+	 */
+	readonly help: string;
+
+	/**
+	 * List of registers attached to the metric.
+	 */
+	readonly registers: readonly Registry[];
+
+	/**
+	 * List of label names attached to the metric.
+	 */
+	readonly labelNames: readonly string[];
+
+	/**
+	 * The aggregation method used for aggregating this metric in a Node.js cluster.
+	 */
+	readonly aggregator: Aggregator;
+
+	/**
+	 * If provided, the collect function of the metric, which is invoked on each scrape.
+	 */
+	readonly collect?: CollectFunction<this>;
+}
+
 /**
  * Aggregation methods, used for aggregating metrics in a Node.js cluster.
  */
@@ -255,7 +287,9 @@ export interface ObserveDataWithExemplar<T extends string> {
 /**
  * A counter is a cumulative metric that represents a single numerical value that only ever goes up
  */
-export class Counter<T extends string = NoLabelNameType> {
+export class Counter<
+	T extends string = NoLabelNameType,
+> extends AbstractMetric {
 	/**
 	 * @param configuration Configuration when creating a Counter metric. Name and Help is required.
 	 */
@@ -335,7 +369,7 @@ export interface GaugeConfiguration<T extends string>
 /**
  * A gauge is a metric that represents a single numerical value that can arbitrarily go up and down.
  */
-export class Gauge<T extends string = NoLabelNameType> {
+export class Gauge<T extends string = NoLabelNameType> extends AbstractMetric {
 	/**
 	 * @param configuration Configuration when creating a Gauge metric. Name and Help is mandatory
 	 */
@@ -476,7 +510,9 @@ export interface HistogramConfiguration<T extends string>
 /**
  * A histogram samples observations (usually things like request durations or response sizes) and counts them in configurable buckets
  */
-export class Histogram<T extends string = NoLabelNameType> {
+export class Histogram<
+	T extends string = NoLabelNameType,
+> extends AbstractMetric {
 	/**
 	 * @param configuration Configuration when creating the Histogram. Name and Help is mandatory
 	 */
@@ -602,7 +638,9 @@ export interface SummaryConfiguration<T extends string>
 /**
  * A summary samples observations
  */
-export class Summary<T extends string = NoLabelNameType> {
+export class Summary<
+	T extends string = NoLabelNameType,
+> extends AbstractMetric {
 	/**
 	 * @param configuration Configuration when creating Summary metric. Name and Help is mandatory
 	 */


### PR DESCRIPTION
The typescript definitions for all 4 metric classes only include methods.

This PR adds properties in the typescript definitions to the 4 metric classes, which come from the abstract `Metric` class.

