### PR TITLE
feat: add option to exclude specific default metrics from collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ This release marks our first release under the Prometheus umbrella.
 
 ### Added
 
+- Add option to exclude selected default metrics from being collected
 - Add `nodejs_eventloop_utilization_summary` and `nodejs_eventloop_utilization_histogram` to the default metrics
 - Add debug logging for metrics collection failures.
 - Node 26 added to the test matrix

--- a/index.d.ts
+++ b/index.d.ts
@@ -767,6 +767,21 @@ export function exponentialBuckets(
 	count: number,
 ): number[];
 
+type AvailableDefaultMetrics =
+	| 'processCpuTotal'
+	| 'processStartTime'
+	| 'osMemoryHeap'
+	| 'processOpenFileDescriptors'
+	| 'processMaxFileDescriptors'
+	| 'eventLoopLag'
+	| 'processResources'
+	| 'processHandles'
+	| 'processRequests'
+	| 'heapSizeAndUsed'
+	| 'heapSpacesSizeAndUsed'
+	| 'version'
+	| 'gc';
+
 export interface DefaultMetricsCollectorConfiguration<
 	T extends RegistryContentType,
 > {
@@ -775,6 +790,7 @@ export interface DefaultMetricsCollectorConfiguration<
 	gcDurationBuckets?: number[];
 	eventLoopMonitoringPrecision?: number;
 	labels?: object;
+	exclude?: AvailableDefaultMetrics[];
 }
 
 export const collectDefaultMetrics: {
@@ -786,7 +802,7 @@ export const collectDefaultMetrics: {
 		config?: DefaultMetricsCollectorConfiguration<T>,
 	): void;
 	/** All available default metrics */
-	metricsList: string[];
+	metricsList: AvailableDefaultMetrics[];
 };
 
 /**

--- a/index.d.ts
+++ b/index.d.ts
@@ -774,6 +774,7 @@ type AvailableDefaultMetrics =
 	| 'processOpenFileDescriptors'
 	| 'processMaxFileDescriptors'
 	| 'eventLoopLag'
+	| 'eventLoopUtilization'
 	| 'processResources'
 	| 'processHandles'
 	| 'processRequests'

--- a/lib/defaultMetrics.js
+++ b/lib/defaultMetrics.js
@@ -42,10 +42,13 @@ module.exports = function collectDefaultMetrics(config) {
 		throw new TypeError('config must be null, undefined, or an object');
 	}
 
-	config = { eventLoopMonitoringPrecision: 10, ...config };
+	config = { eventLoopMonitoringPrecision: 10, exclude: [], ...config };
 
-	for (const metric of Object.values(metrics)) {
-		metric(config.register, config);
+	for (const metricGroup in metrics) {
+		if (config.exclude.includes(metricGroup)) {
+			continue;
+		}
+		metrics[metricGroup](config.register, config);
 	}
 };
 

--- a/lib/defaultMetrics.js
+++ b/lib/defaultMetrics.js
@@ -44,7 +44,7 @@ module.exports = function collectDefaultMetrics(config) {
 
 	config = { eventLoopMonitoringPrecision: 10, exclude: [], ...config };
 
-	for (const metricGroup in metrics) {
+	for (const metricGroup of Object.keys(metrics)) {
 		if (config.exclude.includes(metricGroup)) {
 			continue;
 		}

--- a/test/defaultMetricsTest.js
+++ b/test/defaultMetricsTest.js
@@ -91,6 +91,22 @@ describe.each([
 		});
 	});
 
+	it('should allow to exclude specific metrics', async () => {
+		expect(await register.getMetricsAsJSON()).toHaveLength(0);
+
+		collectDefaultMetrics();
+		expect(
+			await register.getSingleMetric('nodejs_eventloop_lag_seconds'),
+		).toBeDefined();
+
+		register.clear();
+
+		collectDefaultMetrics({ exclude: ['eventLoopLag'] });
+		expect(
+			await register.getSingleMetric('nodejs_eventloop_lag_seconds'),
+		).toBeUndefined();
+	});
+
 	describe('disabling', () => {
 		it('should not throw error', () => {
 			const fn = function () {


### PR DESCRIPTION
Fixes: https://github.com/siimon/prom-client/issues/623 (I believe it was incorrectly marked as fixed)

This PR adds `exclude` option to the `DefaultMetricsCollectorConfiguration` that allows to omit certain group of metrics from being collected.

My own use case is that I use a custom implementation of `eventLoopLag` metrics (though based on the original one), so I need to exclude them to avoid conflicts in registry, but others may want to also use it to remove redundant and unused metrics.

An alternative approach would be to expose the exports from `lib/metrics` in the public interface, allowing users to import and manually register only the specific metrics they need. I’m not sure, though, which approach is better - this one or the `exclude` approach.