### PR TITLE
Fixed OpenMetrics Content-Type support for `cluster` module

### DIFF
--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -28,7 +28,7 @@ const requests = new Map(); // Pending requests for workers' local metrics.
 class AggregatorRegistry extends Registry {
 	constructor(regContentType = Registry.PROMETHEUS_CONTENT_TYPE) {
 		super(regContentType);
-		addListeners();
+		addListeners(regContentType);
 	}
 
 	/**
@@ -131,9 +131,10 @@ class AggregatorRegistry extends Registry {
 /**
  * Adds event listeners for cluster aggregation. Idempotent (safe to call more
  * than once).
+ * @param {string} registryType content type of the aggregated registry.
  * @returns {void}
  */
-function addListeners() {
+function addListeners(registryType) {
 	if (listenersAdded) return;
 	listenersAdded = true;
 
@@ -159,7 +160,7 @@ function addListeners() {
 					// finalize
 					clearTimeout(request.errorTimeout);
 
-					const registry = Registry.aggregate(request.responses);
+					const registry = Registry.aggregate(request.responses, registryType);
 					const promString = registry.metrics();
 					request.done(undefined, promString);
 				}


### PR DESCRIPTION
There's a call to `Registry.aggregate` that does not pass in any value to the register content-type parameter. This causes the cluster/worker aggregator to always return `PROMETHEUS_CONTENT_TYPE` formatted metrics, instead of `OPENMETRICS_CONTENT_TYPE`, even when the latter is used when constructing the original `AggregatorRegistry`.

This commit fixes support for `Registry.OPENMETRICS_CONTENT_TYPE` by passing the AggregatorRegistry's content-type into the call to `Registry.Aggregate` within the cluster metrics response listener.