### PR TITLE
Deprecate functions that were replaced by LabelMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This release marks our first release under the Prometheus umbrella.
 - chore: Add copyright license headers and test
 - Make cluster and worker-thread metric aggregation order deterministic
 - Export `MetricObject`, `MetricObjectWithValues`, `MetricValue` and `MetricValueWithName` from the TypeScript definitions
+- chore: Old label processing code marked as deprecated
 
 ### Added
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -32,6 +32,7 @@ exports.getValueAsString = function getValueString(value) {
 
 /**
  * @function removeLabels
+ * @deprecated please use LabelMap
  * @param {Map} hashMap
  * @param {string[]} labels
  * @param {string[]} sortedLabelNames
@@ -46,6 +47,7 @@ exports.removeLabels = function removeLabels(
 
 /**
  * @function setValue
+ * @deprecated please use LabelMap
  * @param {Map} hashMap
  * @param {*} value
  * @param {object} labels
@@ -61,6 +63,7 @@ exports.setValue = function setValue(hashMap, value, labels) {
 
 /**
  * @function setValueDelta
+ * @deprecated please use LabelMap
  * @param {Map} hashMap
  * @param {*} deltaValue
  * @param {object} labels
@@ -142,6 +145,10 @@ function hashObject(labels, labelNames) {
 
 	return fastHashObject(keys, labels);
 }
+
+/**
+ * @deprecated please use LabelMap
+ */
 exports.hashObject = hashObject;
 
 exports.isObject = function isObject(obj) {


### PR DESCRIPTION
These functions are exposed by the public API and are likely to be used by third party custom Metrics, so cannot simply be deleted.