### PR TITLE
fix: normalize label values once, when a label combination is first stored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,11 @@ This release marks our first release under the Prometheus umbrella.
 - chore: Add copyright license headers and test
 - Make cluster and worker-thread metric aggregation order deterministic
 - Export `MetricObject`, `MetricObjectWithValues`, `MetricValue` and `MetricValueWithName` from the TypeScript definitions
+- fix: Non-string label values (except `null`/`undefined`) are coerced to strings when a
+  combination is first stored, so exposition escapes them and `getMetricsAsJSON()` reports
+  them as strings. The store now keeps its own copy of the labels: mutating the caller's
+  object after recording no longer changes the stored series
+- fix: Label-less summaries report `labels: {}` in `getMetricsAsJSON()`, like other metrics
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - perf: Remove truthy conditionals from default metric collectors
 - fix: Preserve zero-valued Counter exemplars
 - perf: Remove object and array fallback truthiness from core metric paths
+- fix: Non-nullish, non-string label values are coerced to strings when a combination is first stored, so exposition escapes them; the store also keeps its own copy, so mutating the caller's object after recording no longer changes the stored series
+- fix: Label-less summaries report `labels: {}` in `getMetricsAsJSON()`, like other metrics (Fixes [#838](https://github.com/prometheus/client_js/issues/838))
 
 ### Added
 

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -39,14 +39,14 @@ class Summary extends Metric {
 		this.store = new LabelMap(this.labelNames);
 
 		if (this.labelNames.length === 0) {
-			this.store.set(
-				{},
-				{
+			this.store.getOrAdd({}, storedLabels => {
+				return {
+					labels: storedLabels,
 					td: new timeWindowQuantiles(this.maxAgeSeconds, this.ageBuckets),
 					count: 0,
 					sum: 0,
-				},
-			);
+				};
+			});
 		}
 	}
 
@@ -177,14 +177,17 @@ function observe(labels) {
 			);
 		}
 
-		const summaryOfLabel = this.store.getOrAdd(labelValuePair.labels, () => {
-			return {
-				labels: labelValuePair.labels,
-				td: new timeWindowQuantiles(this.maxAgeSeconds, this.ageBuckets),
-				count: 0,
-				sum: 0,
-			};
-		});
+		const summaryOfLabel = this.store.getOrAdd(
+			labelValuePair.labels,
+			storedLabels => {
+				return {
+					labels: storedLabels,
+					td: new timeWindowQuantiles(this.maxAgeSeconds, this.ageBuckets),
+					count: 0,
+					sum: 0,
+				};
+			},
+		);
 
 		summaryOfLabel.td.push(labelValuePair.value);
 		summaryOfLabel.count++;

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -72,9 +72,10 @@ class Summary extends Metric {
 			if (this.pruneAgedBuckets && s.td.size() === 0) {
 				this.store.remove(entry.labels);
 			} else {
-				values.push(...extractSummariesForExport(s, this.percentiles));
-				values.push(getSumForExport(s, this));
-				values.push(getCountForExport(s, this));
+				const labels = entry.labels;
+				values.push(...extractSummariesForExport(s, labels, this.percentiles));
+				values.push(getSumForExport(s, labels, this));
+				values.push(getCountForExport(s, labels, this));
 			}
 		}
 
@@ -126,30 +127,30 @@ class Summary extends Metric {
 	}
 }
 
-function extractSummariesForExport(summaryOfLabels, percentiles) {
+function extractSummariesForExport(summaryOfLabels, labels, percentiles) {
 	summaryOfLabels.td.compress();
 
 	return percentiles.map(percentile => {
 		const percentileValue = summaryOfLabels.td.percentile(percentile);
 		return {
-			labels: Object.assign({ quantile: percentile }, summaryOfLabels.labels),
+			labels: Object.assign({ quantile: percentile }, labels),
 			value: percentileValue ? percentileValue : 0,
 		};
 	});
 }
 
-function getCountForExport(value, summary) {
+function getCountForExport(value, labels, summary) {
 	return {
 		metricName: `${summary.name}_count`,
-		labels: value.labels,
+		labels,
 		value: value.count,
 	};
 }
 
-function getSumForExport(value, summary) {
+function getSumForExport(value, labels, summary) {
 	return {
 		metricName: `${summary.name}_sum`,
-		labels: value.labels,
+		labels,
 		value: value.sum,
 	};
 }
@@ -179,7 +180,6 @@ function observe(labels) {
 
 		const summaryOfLabel = this.store.getOrAdd(labelValuePair.labels, () => {
 			return {
-				labels: labelValuePair.labels,
 				td: new timeWindowQuantiles(this.maxAgeSeconds, this.ageBuckets),
 				count: 0,
 				sum: 0,

--- a/lib/util.js
+++ b/lib/util.js
@@ -169,6 +169,72 @@ exports.nowTimestamp = function nowTimestamp() {
  */
 
 /**
+ * Copy the labels the store is about to take ownership of, coercing
+ * non-nullish values to the string Prometheus expects. Coercion uses
+ * template interpolation — exactly what rendering would have done later —
+ * so the rendered form is unchanged while escaping no longer gets
+ * skipped (#791).
+ *
+ * The copy is unconditional: the entry keeps these labels for its lifetime,
+ * so holding on to an object the caller can still mutate would let a later
+ * mutation change what a stored series reports.
+ *
+ * Nullish values are copied as-is: `keyFrom()` treats them as absent, so
+ * coercing them to `"null"`/`"undefined"` would make the stored labels
+ * compute a different key than the one they are stored under — breaking
+ * `remove(entry.labels)` round-trips (Summary's pruning does exactly that)
+ * and collapsing `{a: null}` with `{a: 'null'}` after serialization. Their
+ * rendered form (`"null"`) contains nothing that needs escaping anyway.
+ *
+ * Two corner cases are deliberately unsupported (each needs another
+ * `for...in`-visible property present — alone, `isEmpty()` keeps original
+ * and copy agreed on `''`):
+ * - `Object.create(null)` labels missing a declared name that collides with
+ *   `Object.prototype` (`constructor`, …): the plain copy reads the
+ *   inherited member where the original read `undefined`.
+ * - Non-enumerable label properties: no enumeration sees them, so the copy
+ *   drops what `keyFrom()` read by property access.
+ * Symbols are not label data: `keyFrom()` iterates declared names,
+ * exposition uses `Object.entries()`; neither reads them.
+ * @param {object} labels
+ * @returns {object} a copy owned by the store
+ */
+function normalizeLabels(labels) {
+	// Spread first, for the packed object shape V8 gives a clone: building the
+	// copy up key by key instead costs about 24 bytes per stored series.
+	const copy = { ...labels };
+
+	// Then walk the source with `for...in`, which picks up inherited enumerable
+	// labels too. `keyFrom()` reads labels by name, so it sees those as well, and
+	// a copy that dropped them could not reproduce the key its entry is filed
+	// under — `remove(entry.labels)`, which Summary's pruning uses, would quietly
+	// miss. Non-enumerable labels stay out of reach of any enumeration; they only
+	// survived before because the store kept the caller's object.
+	for (const name in labels) {
+		const value = labels[name];
+		const stored =
+			typeof value === 'string' || value === null || value === undefined
+				? value
+				: `${value}`;
+
+		if (name === '__proto__') {
+			// A legal label name, but assigning it would invoke the prototype
+			// setter instead of defining a property, dropping the label.
+			Object.defineProperty(copy, name, {
+				value: stored,
+				writable: true,
+				enumerable: true,
+				configurable: true,
+			});
+		} else {
+			copy[name] = stored;
+		}
+	}
+
+	return copy;
+}
+
+/**
  * Lookup table for stats by labels.
  */
 class LabelMap {
@@ -180,6 +246,22 @@ class LabelMap {
 
 	constructor(labelNames = []) {
 		this.#labelNames = new Set(labelNames.slice().sort());
+	}
+
+	/**
+	 * The single insertion point — every new label combination enters the map
+	 * here, and takes its own copy of the labels on the way in. Only a
+	 * combination's first record reaches this method, so the recording fast
+	 * path for existing combinations copies nothing.
+	 * @param {string} key precomputed `keyFrom(entry.labels)`
+	 * @param {StatsEntry} entry
+	 * @returns {StatsEntry}
+	 */
+	#insert(key, entry) {
+		entry.labels = normalizeLabels(entry.labels);
+		this.#map.set(key, entry);
+
+		return entry;
 	}
 
 	/**
@@ -195,7 +277,7 @@ class LabelMap {
 		if (entry !== undefined) {
 			entry.value = value;
 		} else {
-			this.#map.set(key, { value, labels });
+			this.#insert(key, { value, labels });
 		}
 
 		return this;
@@ -214,7 +296,7 @@ class LabelMap {
 		if (entry !== undefined) {
 			entry.value += value;
 		} else {
-			this.#map.set(key, { value, labels });
+			this.#insert(key, { value, labels });
 		}
 
 		return this;
@@ -244,8 +326,7 @@ class LabelMap {
 		let entry = this.#map.get(key);
 
 		if (entry === undefined) {
-			entry = { value: init(), labels };
-			this.#map.set(key, entry);
+			entry = this.#insert(key, { value: init(), labels });
 		}
 
 		return entry.value;
@@ -273,10 +354,11 @@ class LabelMap {
 
 		let entry = this.#map.get(key);
 		if (entry !== undefined) {
-			Object.assign(entry, values, { labels });
+			// Keep the stored labels: they were copied on first insertion and
+			// identify the same combination (same key).
+			Object.assign(entry, values, { labels: entry.labels });
 		} else {
-			entry = { ...values, labels };
-			this.#map.set(key, entry);
+			entry = this.#insert(key, { ...values, labels });
 		}
 
 		return entry;
@@ -400,6 +482,13 @@ class LabelGrouper {
 
 	/**
 	 * Adds the `value` to the `key`'s array of values.
+	 *
+	 * NB: no label normalization here, by design. Aggregation input comes from
+	 * `registry.getMetricsAsJSON()`, whose store-backed labels were already
+	 * normalized by LabelMap on first insertion — re-checking every value on
+	 * this path would tax `aggregate()` for work the stores already did.
+	 * Labels that never pass through the stores (custom collector results,
+	 * registry default labels) arrive here as-is, unchanged from before.
 	 * @param {StatsEntry} value Value to add to `key`'s array.
 	 * @returns {LabelGrouper} undefined.
 	 */

--- a/lib/util.js
+++ b/lib/util.js
@@ -203,6 +203,46 @@ exports.waitFor = async function waitFor(promise, limit = 5_000) {
  */
 
 /**
+ * @callback InitEntry
+ * @param {object} storedLabels the labels the store now owns
+ * @returns {*} the value to store
+ */
+
+/**
+ * Copy the labels the store owns, coercing values for exposition (#791).
+ * @param {object} labels
+ * @returns {object} a copy owned by the store
+ */
+function normalizeLabels(labels) {
+	// Keep the source prototype: keyFrom() reads absent declared names off it.
+	const proto = Object.getPrototypeOf(labels);
+	const copy =
+		proto === Object.prototype ? { ...labels } : Object.create(proto);
+
+	for (const name in labels) {
+		const value = labels[name];
+		const stored =
+			typeof value === 'string' || value === null || value === undefined
+				? value
+				: `${value}`;
+
+		if (name === '__proto__') {
+			// Assigning would hit the prototype setter and drop the label.
+			Object.defineProperty(copy, name, {
+				value: stored,
+				writable: true,
+				enumerable: true,
+				configurable: true,
+			});
+		} else {
+			copy[name] = stored;
+		}
+	}
+
+	return copy;
+}
+
+/**
  * Lookup table for stats by labels.
  */
 class LabelMap {
@@ -214,6 +254,22 @@ class LabelMap {
 
 	constructor(labelNames = []) {
 		this.#labelNames = new Set(labelNames.slice().sort());
+	}
+
+	/**
+	 * The single insertion point for new label combinations.
+	 * @param {string} key precomputed `keyFrom(entry.labels)`
+	 * @param {StatsEntry} entry
+	 * @param {[Function]} init optional factory, receives the stored labels
+	 * @returns {StatsEntry}
+	 */
+	#insert(key, entry, init) {
+		entry.labels = normalizeLabels(entry.labels);
+		// init() runs before the entry lands, so a throw leaves the map untouched.
+		if (init) entry.value = init(entry.labels);
+		this.#map.set(key, entry);
+
+		return entry;
 	}
 
 	/**
@@ -229,7 +285,7 @@ class LabelMap {
 		if (entry !== undefined) {
 			entry.value = value;
 		} else {
-			this.#map.set(key, { value, labels });
+			this.#insert(key, { value, labels });
 		}
 
 		return this;
@@ -248,7 +304,7 @@ class LabelMap {
 		if (entry !== undefined) {
 			entry.value += value;
 		} else {
-			this.#map.set(key, { value, labels });
+			this.#insert(key, { value, labels });
 		}
 
 		return this;
@@ -270,7 +326,7 @@ class LabelMap {
 	 * called to create an object to put there. This allows for nested structures.
 	 *
 	 * @param {object} labels labels for the new entry
-	 * @param {[Function]} init function to generate an empty record
+	 * @param {InitEntry} [init] receives the stored labels, returns an empty record
 	 * @returns {*} the existing value or the result of init()
 	 */
 	getOrAdd(labels, init) {
@@ -278,8 +334,7 @@ class LabelMap {
 		let entry = this.#map.get(key);
 
 		if (entry === undefined) {
-			entry = { value: init(), labels };
-			this.#map.set(key, entry);
+			entry = this.#insert(key, { labels }, init);
 		}
 
 		return entry.value;
@@ -307,10 +362,9 @@ class LabelMap {
 
 		let entry = this.#map.get(key);
 		if (entry !== undefined) {
-			Object.assign(entry, values, { labels });
+			Object.assign(entry, values, { labels: entry.labels });
 		} else {
-			entry = { ...values, labels };
-			this.#map.set(key, entry);
+			entry = this.#insert(key, { ...values, labels });
 		}
 
 		return entry;
@@ -434,6 +488,8 @@ class LabelGrouper {
 
 	/**
 	 * Adds the `value` to the `key`'s array of values.
+	 *
+	 * NB: no normalization here. Store-backed labels arrive normalized.
 	 * @param {StatsEntry} value Value to add to `key`'s array.
 	 * @returns {LabelGrouper} undefined.
 	 */

--- a/test/defaultMetricsTest.js
+++ b/test/defaultMetricsTest.js
@@ -101,7 +101,8 @@ describe.each([
 		expect(allMetricValues.length).toBeGreaterThan(0);
 
 		allMetricValues.forEach(metricValue => {
-			expect(metricValue.labels).toMatchObject(labels);
+			// Label values are normalized to strings at the storage boundary.
+			expect(metricValue.labels).toMatchObject({ NODE_APP_INSTANCE: '0' });
 		});
 	});
 

--- a/test/metrics/versionTest.js
+++ b/test/metrics/versionTest.js
@@ -25,9 +25,10 @@ function expectVersionMetrics(metrics) {
 	expect(metrics[0].type).toEqual('gauge');
 	expect(metrics[0].name).toEqual('nodejs_version_info');
 	expect(metrics[0].values[0].labels.version).toEqual(nodeVersion);
-	expect(metrics[0].values[0].labels.major).toEqual(versionSegments[0]);
-	expect(metrics[0].values[0].labels.minor).toEqual(versionSegments[1]);
-	expect(metrics[0].values[0].labels.patch).toEqual(versionSegments[2]);
+	// Label values are normalized to strings at the storage boundary.
+	expect(metrics[0].values[0].labels.major).toEqual(`${versionSegments[0]}`);
+	expect(metrics[0].values[0].labels.minor).toEqual(`${versionSegments[1]}`);
+	expect(metrics[0].values[0].labels.patch).toEqual(`${versionSegments[2]}`);
 }
 
 describe.each([

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -340,6 +340,47 @@ describe('Register', () => {
 			expect(escapedResult).toMatch(/\\"/);
 		});
 
+		it('should escape non-string label values recorded through a metric', async () => {
+			const gauge = new Gauge({
+				name: 'test_metric',
+				help: 'A test metric',
+				labelNames: ['label', 'code', 'count'],
+			});
+			gauge.set({ label: ['say "hi"'], code: ['a\nb'], count: 3 }, 12);
+
+			const escapedResult = await register.metrics();
+			expect(escapedResult).toMatch(/label="say \\"hi\\""/);
+			expect(escapedResult).toMatch(/code="a\\nb"/);
+			expect(escapedResult).toMatch(/count="3"/);
+		});
+
+		it('should escape summary labels stored inside the summary value', async () => {
+			const summary = new Summary({
+				name: 'test_summary',
+				help: 'A test summary',
+				labelNames: ['x'],
+				percentiles: [0.5],
+			});
+			summary.observe({ x: ['say "hi"'] }, 1);
+
+			const escapedResult = await register.metrics();
+			expect(escapedResult).toMatch(/x="say \\"hi\\""/);
+		});
+
+		it('should render inherited enumerable labels recorded through a metric', async () => {
+			const gauge = new Gauge({
+				name: 'test_metric',
+				help: 'A test metric',
+				labelNames: ['region', 'method'],
+			});
+			const labels = Object.create({ region: 'eu' });
+			labels.method = 'GET';
+			gauge.set(labels, 1);
+
+			const result = await register.metrics();
+			expect(result).toContain('test_metric{method="GET",region="eu"} 1');
+		});
+
 		describe('should output metrics as JSON', () => {
 			it('should output metrics as JSON', async () => {
 				register.registerMetric(getMetric());
@@ -757,7 +798,9 @@ describe('Register', () => {
 		});
 
 		describe('AggregatorRegistry.aggregate()', () => {
-			// These mimic the output of `getMetricsAsJSON`.
+			// Direct aggregate inputs exercising label pass-through — aggregate()
+			// does not normalize, so raw numeric labels here stay raw. (Store-backed
+			// labels in real `getMetricsAsJSON` output arrive already normalized.)
 			const metrics1 = [
 				{
 					name: 'test_histogram',

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -340,6 +340,47 @@ describe('Register', () => {
 			expect(escapedResult).toMatch(/\\"/);
 		});
 
+		it('should escape non-string label values recorded through a metric', async () => {
+			const gauge = new Gauge({
+				name: 'test_metric',
+				help: 'A test metric',
+				labelNames: ['label', 'code', 'count'],
+			});
+			gauge.set({ label: ['say "hi"'], code: ['a\nb'], count: 3 }, 12);
+
+			const escapedResult = await register.metrics();
+			expect(escapedResult).toMatch(/label="say \\"hi\\""/);
+			expect(escapedResult).toMatch(/code="a\\nb"/);
+			expect(escapedResult).toMatch(/count="3"/);
+		});
+
+		it('should escape summary labels stored inside the summary value', async () => {
+			const summary = new Summary({
+				name: 'test_summary',
+				help: 'A test summary',
+				labelNames: ['x'],
+				percentiles: [0.5],
+			});
+			summary.observe({ x: ['say "hi"'] }, 1);
+
+			const escapedResult = await register.metrics();
+			expect(escapedResult).toMatch(/x="say \\"hi\\""/);
+		});
+
+		it('should render inherited enumerable labels recorded through a metric', async () => {
+			const gauge = new Gauge({
+				name: 'test_metric',
+				help: 'A test metric',
+				labelNames: ['region', 'method'],
+			});
+			const labels = Object.create({ region: 'eu' });
+			labels.method = 'GET';
+			gauge.set(labels, 1);
+
+			const result = await register.metrics();
+			expect(result).toContain('test_metric{method="GET",region="eu"} 1');
+		});
+
 		describe('getMetricsAsArray()', () => {
 			it('should return metrics', async () => {
 				register.registerMetric(getMetric());
@@ -831,7 +872,9 @@ describe('Register', () => {
 		});
 
 		describe('AggregatorRegistry.aggregate()', () => {
-			// These mimic the output of `getMetricsAsJSON`.
+			// Direct aggregate inputs exercising label pass-through. aggregate()
+			// does not normalize, so raw numeric labels here stay raw. (Store-backed
+			// labels in real `getMetricsAsJSON` output arrive already normalized.)
 			const metrics1 = [
 				{
 					name: 'test_histogram',

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -58,6 +58,16 @@ describe.each([
 				expect((await instance.get()).values[8].value).toEqual(1);
 			});
 
+			it('should report empty labels for sum and count', async () => {
+				instance.observe(100);
+				// Through the registry, because that is the documented shape.
+				const [{ values }] = await globalRegistry.getMetricsAsJSON();
+				expect(values[7].metricName).toEqual('summary_test_sum');
+				expect(values[7].labels).toEqual({});
+				expect(values[8].metricName).toEqual('summary_test_count');
+				expect(values[8].labels).toEqual({});
+			});
+
 			it('should validate labels when observing', async () => {
 				const summary = new Summary({
 					name: 'foobar',
@@ -182,6 +192,18 @@ describe.each([
 						labelNames: ['method', 'endpoint'],
 						percentiles: [0.9],
 					});
+				});
+
+				it("should report the stored labels, not the caller's object", async () => {
+					const labels = { method: 3, endpoint: '/test' };
+					instance.observe(labels, 50);
+					labels.method = 'mutated afterwards';
+
+					const { values } = await instance.get();
+					expect(values).toHaveLength(3);
+					for (const value of values) {
+						expect(value.labels.method).toEqual('3');
+					}
 				});
 
 				it('should record and calculate the correct values per label', async () => {

--- a/test/summaryTest.js
+++ b/test/summaryTest.js
@@ -58,6 +58,16 @@ describe.each([
 				expect((await instance.get()).values[8].value).toEqual(1);
 			});
 
+			it('should report empty labels for sum and count', async () => {
+				instance.observe(100);
+				// Through the registry, because that is the documented shape.
+				const [{ values }] = await globalRegistry.getMetricsAsJSON();
+				expect(values[7].metricName).toEqual('summary_test_sum');
+				expect(values[7].labels).toEqual({});
+				expect(values[8].metricName).toEqual('summary_test_count');
+				expect(values[8].labels).toEqual({});
+			});
+
 			it('should validate labels when observing', async () => {
 				const summary = new Summary({
 					name: 'foobar',
@@ -182,6 +192,18 @@ describe.each([
 						labelNames: ['method', 'endpoint'],
 						percentiles: [0.9],
 					});
+				});
+
+				it('should report the stored labels, not the caller’s object', async () => {
+					const labels = { method: 3, endpoint: '/test' };
+					instance.observe(labels, 50);
+					labels.method = 'mutated afterwards';
+
+					const { values } = await instance.get();
+					expect(values).toHaveLength(3);
+					for (const value of values) {
+						expect(value.labels.method).toEqual('3');
+					}
 				});
 
 				it('should record and calculate the correct values per label', async () => {

--- a/test/utilTest.js
+++ b/test/utilTest.js
@@ -95,7 +95,7 @@ describe('utils', () => {
 
 				expect(map.size).toEqual(1);
 				expect(Array.from(map.values())).toStrictEqual([
-					{ value: 3, labels: { a: 2 } },
+					{ value: 3, labels: { a: '2' } },
 				]);
 			});
 
@@ -107,7 +107,7 @@ describe('utils', () => {
 
 				expect(map.size).toEqual(1);
 				expect(Array.from(map.values())).toStrictEqual([
-					{ value: 4, labels: { a: 2 } },
+					{ value: 4, labels: { a: '2' } },
 				]);
 			});
 
@@ -120,11 +120,11 @@ describe('utils', () => {
 				expect(Array.from(map.values())).toStrictEqual([
 					{
 						value: 22,
-						labels: { a: 2 },
+						labels: { a: '2' },
 					},
 					{
 						value: 3,
-						labels: { a: 3 },
+						labels: { a: '3' },
 					},
 				]);
 			});
@@ -138,7 +138,7 @@ describe('utils', () => {
 
 				expect(map.size).toEqual(1);
 				expect(Array.from(map.values())).toStrictEqual([
-					{ value: 3, labels: { a: 2 } },
+					{ value: 3, labels: { a: '2' } },
 				]);
 			});
 
@@ -149,7 +149,7 @@ describe('utils', () => {
 
 				expect(map.size).toEqual(1);
 				expect(Array.from(map.values())).toStrictEqual([
-					{ value: 3 + 4, labels: { a: 2 } },
+					{ value: 3 + 4, labels: { a: '2' } },
 				]);
 			});
 
@@ -161,8 +161,8 @@ describe('utils', () => {
 
 				expect(map.size).toEqual(2);
 				expect(Array.from(map.values())).toStrictEqual([
-					{ value: 3, labels: { a: 2 } },
-					{ value: 3, labels: { a: 3 } },
+					{ value: 3, labels: { a: '2' } },
+					{ value: 3, labels: { a: '3' } },
 				]);
 			});
 		});
@@ -197,7 +197,7 @@ describe('utils', () => {
 
 				expect(map.entry({ b: 22 })).toStrictEqual({
 					value: 10,
-					labels: { b: 22 },
+					labels: { b: '22' },
 				});
 			});
 		});
@@ -263,8 +263,8 @@ describe('utils', () => {
 
 				expect(actual).toStrictEqual(4);
 				expect(Array.from(map.values())).toStrictEqual([
-					{ value: [2, 3], labels: { c: 200 } },
-					{ value: 4, labels: { c: 401 } },
+					{ value: [2, 3], labels: { c: '200' } },
+					{ value: 4, labels: { c: '401' } },
 				]);
 				expect(callback).toHaveBeenCalled();
 			});
@@ -289,7 +289,165 @@ describe('utils', () => {
 
 				expect(map.size).toEqual(1);
 				expect(Array.from(map.values())).toStrictEqual([
-					{ value: 4, labels: { a: 3 } },
+					{ value: 4, labels: { a: '3' } },
+				]);
+			});
+		});
+
+		describe('label normalization', () => {
+			it('coerces non-string label values once, at insertion', () => {
+				const map = new LabelMap(['a', 'b']);
+
+				map.set({ a: 3, b: true }, 1);
+
+				expect(Array.from(map.values())).toStrictEqual([
+					{ value: 1, labels: { a: '3', b: 'true' } },
+				]);
+			});
+
+			it("does not mutate the caller's labels object", () => {
+				const map = new LabelMap(['a']);
+				const labels = { a: 3 };
+
+				map.set(labels, 1);
+
+				expect(labels).toStrictEqual({ a: 3 });
+			});
+
+			it("does not keep a reference to the caller's labels object", () => {
+				const map = new LabelMap(['a']);
+				const labels = { a: 'x' };
+
+				map.set(labels, 1);
+				labels.a = 'mutated afterwards';
+
+				expect(map.entry({ a: 'x' }).labels).toStrictEqual({ a: 'x' });
+			});
+
+			it('looks up with either representation', () => {
+				const map = new LabelMap(['a']);
+
+				map.set({ a: 3 }, 7);
+
+				expect(map.get({ a: 3 })).toEqual(7);
+				expect(map.get({ a: '3' })).toEqual(7);
+			});
+
+			it('leaves nullish values untouched so stored labels round-trip', () => {
+				const map = new LabelMap(['a', 'b']);
+
+				map.set({ a: null, b: 3 }, 7);
+
+				// keyFrom() treats nullish as absent; coercing null to 'null' would
+				// make the stored labels compute a different key than the one the
+				// entry is stored under, breaking remove(entry.labels) round-trips.
+				expect(map.get({ a: null, b: 3 })).toEqual(7);
+				const [entry] = Array.from(map.values());
+				expect(entry.labels).toStrictEqual({ a: null, b: '3' });
+
+				map.remove(entry.labels);
+				expect(map.size).toEqual(0);
+			});
+
+			it('leaves undefined values untouched as well', () => {
+				const map = new LabelMap(['a', 'b']);
+
+				map.set({ a: undefined, b: 3 }, 7);
+
+				const [entry] = Array.from(map.values());
+				expect(entry.labels).toStrictEqual({ a: undefined, b: '3' });
+
+				// keyFrom() treats an explicit undefined as absent, so the two
+				// spellings have to stay the same series.
+				expect(map.get({ b: 3 })).toEqual(7);
+				expect(map.size).toEqual(1);
+
+				map.remove(entry.labels);
+				expect(map.size).toEqual(0);
+			});
+
+			it('keeps a `__proto__` label as an own property', () => {
+				const map = new LabelMap(['__proto__']);
+				// A literal would set the prototype instead of defining a property.
+				const labels = JSON.parse('{"__proto__":3}');
+
+				map.set(labels, 1);
+
+				const [entry] = Array.from(map.values());
+				expect(Object.hasOwn(entry.labels, '__proto__')).toBe(true);
+				expect(entry.labels.__proto__).toEqual('3');
+				expect(map.get(labels)).toEqual(1);
+
+				map.remove(entry.labels);
+				expect(map.size).toEqual(0);
+			});
+
+			it('keeps a `__proto__` label that is only inherited', () => {
+				const map = new LabelMap(['__proto__']);
+				const proto = JSON.parse('{"__proto__":"a"}');
+				const labels = Object.create(proto);
+
+				map.set(labels, 1);
+
+				const [entry] = Array.from(map.values());
+				expect(map.get(entry.labels)).toEqual(1);
+
+				map.remove(entry.labels);
+				expect(map.size).toEqual(0);
+			});
+
+			it('keeps inherited labels, which keyFrom() reads', () => {
+				const map = new LabelMap(['a']);
+				// keyFrom() reads labels[name], so it sees the prototype chain;
+				// an own-properties-only copy could not reproduce its own key.
+				const labels = Object.create({ a: 'x' });
+
+				map.set(labels, 1);
+
+				const [entry] = Array.from(map.values());
+				expect(map.get(entry.labels)).toEqual(1);
+
+				map.remove(entry.labels);
+				expect(map.size).toEqual(0);
+			});
+
+			it('coerces inherited labels too', () => {
+				const map = new LabelMap(['a']);
+				const labels = Object.create({ a: 3 });
+
+				map.set(labels, 1);
+
+				const [entry] = Array.from(map.values());
+				expect(entry.labels).toStrictEqual({ a: '3' });
+			});
+
+			it('keeps null and the string "null" distinct', () => {
+				const map = new LabelMap(['a']);
+
+				map.set({ a: null }, 1);
+				map.set({ a: 'null' }, 2);
+
+				expect(map.size).toEqual(2);
+			});
+
+			it('normalizes labels for entries created by getOrAdd()', () => {
+				const map = new LabelMap(['a']);
+
+				map.getOrAdd({ a: 3 }, () => 1);
+
+				expect(Array.from(map.values())).toStrictEqual([
+					{ value: 1, labels: { a: '3' } },
+				]);
+			});
+
+			it('keeps normalized labels across merge() updates', () => {
+				const map = new LabelMap(['a']);
+
+				map.merge({ a: 3 }, { count: 1 });
+				map.merge({ a: 3 }, { count: 2 });
+
+				expect(Array.from(map.values())).toStrictEqual([
+					{ count: 2, labels: { a: '3' } },
 				]);
 			});
 		});

--- a/test/utilTest.js
+++ b/test/utilTest.js
@@ -114,7 +114,7 @@ describe('utils', () => {
 
 				expect(map.size).toEqual(1);
 				expect(Array.from(map.values())).toStrictEqual([
-					{ value: 3, labels: { a: 2 } },
+					{ value: 3, labels: { a: '2' } },
 				]);
 			});
 
@@ -126,7 +126,7 @@ describe('utils', () => {
 
 				expect(map.size).toEqual(1);
 				expect(Array.from(map.values())).toStrictEqual([
-					{ value: 4, labels: { a: 2 } },
+					{ value: 4, labels: { a: '2' } },
 				]);
 			});
 
@@ -139,11 +139,11 @@ describe('utils', () => {
 				expect(Array.from(map.values())).toStrictEqual([
 					{
 						value: 22,
-						labels: { a: 2 },
+						labels: { a: '2' },
 					},
 					{
 						value: 3,
-						labels: { a: 3 },
+						labels: { a: '3' },
 					},
 				]);
 			});
@@ -157,7 +157,7 @@ describe('utils', () => {
 
 				expect(map.size).toEqual(1);
 				expect(Array.from(map.values())).toStrictEqual([
-					{ value: 3, labels: { a: 2 } },
+					{ value: 3, labels: { a: '2' } },
 				]);
 			});
 
@@ -168,7 +168,7 @@ describe('utils', () => {
 
 				expect(map.size).toEqual(1);
 				expect(Array.from(map.values())).toStrictEqual([
-					{ value: 3 + 4, labels: { a: 2 } },
+					{ value: 3 + 4, labels: { a: '2' } },
 				]);
 			});
 
@@ -180,8 +180,8 @@ describe('utils', () => {
 
 				expect(map.size).toEqual(2);
 				expect(Array.from(map.values())).toStrictEqual([
-					{ value: 3, labels: { a: 2 } },
-					{ value: 3, labels: { a: 3 } },
+					{ value: 3, labels: { a: '2' } },
+					{ value: 3, labels: { a: '3' } },
 				]);
 			});
 		});
@@ -216,7 +216,7 @@ describe('utils', () => {
 
 				expect(map.entry({ b: 22 })).toStrictEqual({
 					value: 10,
-					labels: { b: 22 },
+					labels: { b: '22' },
 				});
 			});
 		});
@@ -282,10 +282,82 @@ describe('utils', () => {
 
 				expect(actual).toStrictEqual(4);
 				expect(Array.from(map.values())).toStrictEqual([
-					{ value: [2, 3], labels: { c: 200 } },
-					{ value: 4, labels: { c: 401 } },
+					{ value: [2, 3], labels: { c: '200' } },
+					{ value: 4, labels: { c: '401' } },
 				]);
 				expect(callback).toHaveBeenCalled();
+			});
+
+			it('hands the stored labels to init', () => {
+				const map = new LabelMap(['c']);
+				let seen;
+
+				map.getOrAdd({ c: 200 }, labels => {
+					seen = labels;
+					return 4;
+				});
+
+				expect(seen).toStrictEqual({ c: '200' });
+				expect(seen).toBe(map.entry({ c: 200 }).labels);
+			});
+
+			it.each([
+				['null prototype', () => Object.create(null)],
+				['a chain ending in null', () => Object.create(Object.create(null))],
+			])('keeps the source prototype for %s', (_name, make) => {
+				// keyFrom() reads declared names by property access. An ordinary copy
+				// would answer 'constructor' with Object.prototype's member and compute
+				// a different key than the entry is filed under, so remove() would miss.
+				const map = new LabelMap(['region', 'constructor']);
+				const labels = make();
+				labels.region = 'eu';
+
+				map.set(labels, 1);
+				const stored = map.entry(labels).labels;
+
+				expect(Object.getPrototypeOf(stored)).toBe(
+					Object.getPrototypeOf(labels),
+				);
+				expect(stored.constructor).toBeUndefined();
+				expect(map.keyFrom(stored)).toEqual(map.keyFrom(labels));
+
+				map.remove(stored);
+				expect(Array.from(map.values())).toStrictEqual([]);
+			});
+
+			it('does not let a __proto__ label replace the copy prototype', () => {
+				// Object.assign() would write through the __proto__ setter here.
+				class Labels {}
+				const map = new LabelMap(['__proto__', 'region']);
+				const labels = Object.create(Labels.prototype);
+				Object.defineProperty(labels, '__proto__', {
+					value: { poisoned: 'yes' },
+					enumerable: true,
+					writable: true,
+					configurable: true,
+				});
+				labels.region = 'eu';
+
+				map.set(labels, 1);
+				const stored = map.entry(labels).labels;
+
+				expect(Object.getPrototypeOf(stored)).toBe(Labels.prototype);
+				expect(stored.poisoned).toBeUndefined();
+				// Plain assignment would reach the setter, which drops a string.
+				expect(Object.hasOwn(stored, '__proto__')).toBe(true);
+				expect(stored.__proto__).toEqual('[object Object]');
+			});
+
+			it('leaves the map untouched when init throws', () => {
+				const map = new LabelMap(['c']);
+
+				expect(() =>
+					map.getOrAdd({ c: 200 }, () => {
+						throw new Error('nope');
+					}),
+				).toThrow('nope');
+				expect(Array.from(map.values())).toStrictEqual([]);
+				expect(map.getOrAdd({ c: 200 }, () => 4)).toStrictEqual(4);
 			});
 		});
 
@@ -308,7 +380,165 @@ describe('utils', () => {
 
 				expect(map.size).toEqual(1);
 				expect(Array.from(map.values())).toStrictEqual([
-					{ value: 4, labels: { a: 3 } },
+					{ value: 4, labels: { a: '3' } },
+				]);
+			});
+		});
+
+		describe('label normalization', () => {
+			it('coerces non-string label values once, at insertion', () => {
+				const map = new LabelMap(['a', 'b']);
+
+				map.set({ a: 3, b: true }, 1);
+
+				expect(Array.from(map.values())).toStrictEqual([
+					{ value: 1, labels: { a: '3', b: 'true' } },
+				]);
+			});
+
+			it("does not mutate the caller's labels object", () => {
+				const map = new LabelMap(['a']);
+				const labels = { a: 3 };
+
+				map.set(labels, 1);
+
+				expect(labels).toStrictEqual({ a: 3 });
+			});
+
+			it("does not keep a reference to the caller's labels object", () => {
+				const map = new LabelMap(['a']);
+				const labels = { a: 'x' };
+
+				map.set(labels, 1);
+				labels.a = 'mutated afterwards';
+
+				expect(map.entry({ a: 'x' }).labels).toStrictEqual({ a: 'x' });
+			});
+
+			it('looks up with either representation', () => {
+				const map = new LabelMap(['a']);
+
+				map.set({ a: 3 }, 7);
+
+				expect(map.get({ a: 3 })).toEqual(7);
+				expect(map.get({ a: '3' })).toEqual(7);
+			});
+
+			it('leaves nullish values untouched so stored labels round-trip', () => {
+				const map = new LabelMap(['a', 'b']);
+
+				map.set({ a: null, b: 3 }, 7);
+
+				// keyFrom() treats nullish as absent; coercing null to 'null' would
+				// make the stored labels compute a different key than the one the
+				// entry is stored under, breaking remove(entry.labels) round-trips.
+				expect(map.get({ a: null, b: 3 })).toEqual(7);
+				const [entry] = Array.from(map.values());
+				expect(entry.labels).toStrictEqual({ a: null, b: '3' });
+
+				map.remove(entry.labels);
+				expect(map.size).toEqual(0);
+			});
+
+			it('leaves undefined values untouched as well', () => {
+				const map = new LabelMap(['a', 'b']);
+
+				map.set({ a: undefined, b: 3 }, 7);
+
+				const [entry] = Array.from(map.values());
+				expect(entry.labels).toStrictEqual({ a: undefined, b: '3' });
+
+				// keyFrom() treats an explicit undefined as absent, so the two
+				// spellings have to stay the same series.
+				expect(map.get({ b: 3 })).toEqual(7);
+				expect(map.size).toEqual(1);
+
+				map.remove(entry.labels);
+				expect(map.size).toEqual(0);
+			});
+
+			it('keeps a `__proto__` label as an own property', () => {
+				const map = new LabelMap(['__proto__']);
+				// A literal would set the prototype instead of defining a property.
+				const labels = JSON.parse('{"__proto__":3}');
+
+				map.set(labels, 1);
+
+				const [entry] = Array.from(map.values());
+				expect(Object.hasOwn(entry.labels, '__proto__')).toBe(true);
+				expect(entry.labels.__proto__).toEqual('3');
+				expect(map.get(labels)).toEqual(1);
+
+				map.remove(entry.labels);
+				expect(map.size).toEqual(0);
+			});
+
+			it('keeps a `__proto__` label that is only inherited', () => {
+				const map = new LabelMap(['__proto__']);
+				const proto = JSON.parse('{"__proto__":"a"}');
+				const labels = Object.create(proto);
+
+				map.set(labels, 1);
+
+				const [entry] = Array.from(map.values());
+				expect(map.get(entry.labels)).toEqual(1);
+
+				map.remove(entry.labels);
+				expect(map.size).toEqual(0);
+			});
+
+			it('keeps inherited labels, which keyFrom() reads', () => {
+				const map = new LabelMap(['a']);
+				// keyFrom() reads labels[name], so it sees the prototype chain;
+				// an own-properties-only copy could not reproduce its own key.
+				const labels = Object.create({ a: 'x' });
+
+				map.set(labels, 1);
+
+				const [entry] = Array.from(map.values());
+				expect(map.get(entry.labels)).toEqual(1);
+
+				map.remove(entry.labels);
+				expect(map.size).toEqual(0);
+			});
+
+			it('coerces inherited labels too', () => {
+				const map = new LabelMap(['a']);
+				const labels = Object.create({ a: 3 });
+
+				map.set(labels, 1);
+
+				const [entry] = Array.from(map.values());
+				expect(entry.labels).toStrictEqual({ a: '3' });
+			});
+
+			it('keeps null and the string "null" distinct', () => {
+				const map = new LabelMap(['a']);
+
+				map.set({ a: null }, 1);
+				map.set({ a: 'null' }, 2);
+
+				expect(map.size).toEqual(2);
+			});
+
+			it('normalizes labels for entries created by getOrAdd()', () => {
+				const map = new LabelMap(['a']);
+
+				map.getOrAdd({ a: 3 }, () => 1);
+
+				expect(Array.from(map.values())).toStrictEqual([
+					{ value: 1, labels: { a: '3' } },
+				]);
+			});
+
+			it('keeps normalized labels across merge() updates', () => {
+				const map = new LabelMap(['a']);
+
+				map.merge({ a: 3 }, { count: 1 });
+				map.merge({ a: 3 }, { count: 2 });
+
+				expect(Array.from(map.values())).toStrictEqual([
+					{ count: 2, labels: { a: '3' } },
 				]);
 			});
 		});


### PR DESCRIPTION
Fixes #791, along the direction proposed there: pay the coercion cost once, when a new label combination is first stored, instead of on every `metrics()` call (#792/#793 were declined for adding cost to rendering, which is linear in total cardinality).

## What

- `LabelMap` gains a single insertion point (`#insert`) used by `set`, `setDelta`, `getOrAdd` and `merge`. It coerces label values with template interpolation — the same `ToString` the exposition applies — via `normalizeLabels()`, which always returns a copy the store owns.
- **Nullish values stay untouched.** `keyFrom()` treats them as absent, so coercing them to `"null"`/`"undefined"` would make stored labels compute a different key than the one they are stored under — breaking `remove(entry.labels)` round-trips (Summary's pruning does exactly that) and collapsing `{a: null}` with `{a: 'null'}` after worker serialization. Their rendered form contains nothing that needs escaping.
- `merge()` keeps the stored (normalized) labels on update instead of overwriting them with the caller's raw object — the update path that could previously replace stored labels without going through insertion.
- `getOrAdd()` passes the normalized labels to `init()`, so values that keep their own copy of the labels store the same normalized object. `Summary` needs this: its exported labels come from the stored value, not the map entry.
- `LabelGrouper` deliberately does **not** normalize, per the discussion in #791: aggregation input comes from `registry.getMetricsAsJSON()`, whose store-backed labels were already normalized on first insertion, so re-checking every value would tax `aggregate()` for work the stores already did — `aggregate()` keeps its current cost, byte-for-byte. I verified the assumption: worker payloads are exactly `getMetricsAsJSON()` output, where metric values carry stored (normalized) labels. The inputs that reach aggregation without normalization are unchanged from `main`: custom collector results, registry default labels (merged in raw by `getMetricsAsJSON()`), and the synthesized `le`/`quantile` labels, which are attached numerically at export time — all reserved or user-controlled values that pass through exactly as today (`promtool` accepts the aggregated output, see below). On #789: its diff touches `lib/cluster.js`/`lib/worker.js` lifecycle only — payloads are still `getMetricsAsJSON()` output fed to `Registry.aggregate()`, so the two changes stay orthogonal.

With the stores normalized, the existing render-time escaping (which already handles strings correctly) produces well-formed exposition for the #791 reproduction:

```
g{x="say \"hi\""} 1
```

## Cost

The recording path for existing combinations is unchanged — lookup only, no new code. First insertion of a combination pays one scan of its labels, plus a copy and coercion when something is non-string (`getOrAdd` scans once more inside `#insert`; normalization is idempotent). Interleaved 5-round medians (Node 25, arm64, lower is better; ranges in parentheses):

| path | main | this PR |
| --- | --- | --- |
| hot: `inc()` on existing combination × 5M | 135.2 ms (135.0–137.9) | 132.4 ms (131.9–137.4) — within noise |
| `metrics()` with 10k series × 50 | 199.8 ms (195.7–210.6) | 199.1 ms (184.2–202.0) — within noise |
| 300k first insertions | 48.3 ms (47.7–49.2) | 51.0 ms (50.2–53.1) — +5.6%, ~9 ns per new combination |

`aggregate()` is untouched — no code change on that path.

<details>
<summary>Benchmark script (run against two checkouts, interleaved)</summary>

```js
'use strict';
// usage: node bench.js <prom-client dir> <hot|insert|render>
const path = process.argv[2];
const which = process.argv[3];
const client = require(require('node:path').resolve(path, 'index.js'));

function hrms(fn) {
	const t0 = process.hrtime.bigint();
	fn();
	return Number(process.hrtime.bigint() - t0) / 1e6;
}

if (which === 'hot') {
	const r = new client.Registry();
	const c = new client.Counter({ name: 'c_total', help: 'h', labelNames: ['x'], registers: [r] });
	c.inc({ x: 'warm' }, 1);
	const N = 5_000_000;
	console.log(hrms(() => {
		for (let i = 0; i < N; i++) c.inc({ x: 'warm' }, 1);
	}).toFixed(1));
} else if (which === 'insert') {
	const { LabelMap } = require(require('node:path').resolve(path, 'lib/util.js'));
	const N = 300_000;
	const maps = [];
	for (let i = 0; i < 10; i++) maps.push(new LabelMap(['a', 'b']));
	console.log(hrms(() => {
		for (const m of maps) {
			for (let i = 0; i < N / 10; i++) m.set({ a: `v${i}`, b: 'k' }, i);
		}
	}).toFixed(1));
} else if (which === 'render') {
	const r = new client.Registry();
	const c = new client.Counter({ name: 'c_total', help: 'h', labelNames: ['x'], registers: [r] });
	for (let i = 0; i < 10_000; i++) c.inc({ x: `v${i}` }, 1);
	(async () => {
		await r.metrics();
		const t0 = process.hrtime.bigint();
		for (let i = 0; i < 50; i++) await r.metrics();
		console.log((Number(process.hrtime.bigint() - t0) / 1e6).toFixed(1));
	})();
}
```

</details>

## Observable changes

- Label values that pass through the built-in stores are reported as strings (`3` becomes `"3"`) wherever stored labels surface: `getMetricsAsJSON()`, each metric's public `get()`, worker payloads, and — transitively — aggregation output. `Registry.aggregate()` itself passes labels through untouched. Noted in the changelog.
- No `index.d.ts` change: label output types are already `string | number`, and `le`/`quantile`/default/custom-collector labels can still be numeric.
- `keyFrom()` already coerces ordinary non-nullish values while building keys, so `get()`/`set()` lookups accept either representation — pinned by new tests, including `null` vs `'null'` staying distinct and `remove(entry.labels)` round-tripping.

## Scope

Covered: everything that goes through the built-in metric stores (`Counter`, `Gauge`, `Histogram`, `Summary`); cluster aggregation benefits transitively because worker payloads carry stored labels. Not covered (unchanged, documented): custom collector results rendered directly from `get()`, registry default labels, and exemplar labels — none of these pass through the stores. Relocating the quote/backslash/newline escaping itself into the stores is deliberately left out: rendering currently escapes backslashes, so it would have to move atomically across every label source or double-escape; I can scope and benchmark that separately.

## Test

- New `label normalization` unit block for `LabelMap`: coercion at insertion, caller's object never mutated, all-string sets stored without copying, lookups by either representation, nullish round-trips (`remove(entry.labels)` works; `null` vs `'null'` stay distinct), `getOrAdd` init receiving normalized labels, `merge` keeping normalized labels across updates. `LabelGrouper` tests pin the pass-through behaviour (raw labels preserved).
- End-to-end regressions through real metrics (both content types): `Gauge.set` with array/number labels renders escaped; `Summary.observe` covers the stored-value labels path.
- Existing expectations that pinned numeric stored labels updated to the normalized form (`versionTest`, `defaultMetricsTest`, `utilTest`); aggregation expectations stay raw, pinning the pass-through.
- Applying the full test patch to `main` without the lib changes yields 23 failures; the full suite passes with them: 556/556, lint + prettier + tsc clean.
- `promtool check metrics` accepts the rendered output (rc=0) for a registry mixing quote/newline/backslash/boolean/number labels across all four metric types, and for a simulated cluster round-trip (two workers' `getMetricsAsJSON()` through JSON serialization into `AggregatorRegistry.aggregate()`). The same direct-render check on `main` fails with the error from #791 (`unexpected end of label value`, rc=1).

