### PR TITLE
Add CHANGELOG entry and README install section for the prometheus-io rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ This release marks our first release under the Prometheus umbrella.
 
 ### Breaking
 
+- The package is renamed from `prom-client` to `@prometheus-io/client`. Update your
+  dependencies and any `require()`/`import` statements accordingly.
+- The cluster and worker thread IPC message types are renamed from `prom-client:*`
+  to `@prometheus-io/client:*`. A cluster primary and its workers must therefore run
+  the same major version.
 - Drop support for Node.js versions 16, 18, 20, 21 and 23
 - Metric internal storage ('hashMap') changed to a separate object, LabelMap. If you have
   subclassed the built-in metric types you may need to adjust your code.
@@ -41,7 +46,7 @@ This release marks our first release under the Prometheus umbrella.
 - ci: Run benchmarks for pull requests
 - ci: switch out deprecated benchmark-regression library for replacement
 - AggregatorRegistry renamed to ClusterRegistry, old name deprecated
-- chore: update faceoff to 1.1
+- chore: update faceoff to 1.3
 - perf: Stat aggregation uses similar strategy to collection. 60% faster aggregation
 - chore: Add copyright license headers and test
 - Make cluster and worker-thread metric aggregation order deterministic

--- a/README.md
+++ b/README.md
@@ -3,6 +3,15 @@
 A prometheus client for Node.js that supports histogram, summaries, gauges and
 counters.
 
+## Installation
+
+```bash
+npm install @prometheus-io/client
+```
+
+This package was previously published as `prom-client`. See the
+[CHANGELOG](CHANGELOG.md) for the breaking changes involved in upgrading.
+
 ## Usage
 
 See example folder for a sample usage. The library does not bundle any web


### PR DESCRIPTION
Stacked on top of #799 — this branch is based on `jdmarshall:prometheus-io`, so until #799 merges the diff here also shows that PR's rename commit. Only the second commit (`CHANGELOG.md`, `README.md`) is new.

#799 renames the package to `@prometheus-io/client` but leaves the change unrecorded, which is why its Changelog Reminder check is red.

Also update the readme with some install instructions.