### PR TITLE
perf(registry): Avoid label array manipulation in the happy path.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ This release marks our first release under the Prometheus umbrella.
 - chore: Old label processing code marked as deprecated
 - Improve cluster support to allow workers to opt out
 - Abort cluster metric responses during process termination
+- perf: Stop rebuilding the label array for every rendered series, and skip shared label handling entirely for values that do not set it; 9-22% faster `metrics()` in the registry benchmarks
 
 ### Added
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -69,24 +69,24 @@ class Registry {
 			this.contentType === Registry.OPENMETRICS_CONTENT_TYPE;
 
 		for (const val of metric.values || []) {
-			let { metricName = name, labels = {} } = val;
-			const { sharedLabels } = val;
-			if (isOpenMetrics && metric.type === 'counter') {
-				metricName = `${metricName}_total`;
-			}
+			const { metricName = name, labels = {}, sharedLabels } = val;
+			const seriesName =
+				isOpenMetrics && metric.type === 'counter'
+					? `${metricName}_total`
+					: metricName;
 
+			// Make a copy before mutating
+			const seriesLabels =
+				defaultLabelNames === undefined ? labels : { ...labels };
 			if (defaultLabelNames !== undefined) {
-				// Make a copy before mutating
-				labels = { ...labels };
-
 				for (const labelName of defaultLabelNames) {
-					labels[labelName] ??= this._defaultLabels[labelName];
+					seriesLabels[labelName] ??= this._defaultLabels[labelName];
 				}
 			}
 
 			// We have to flatten these separately to avoid duplicate labels appearing
 			// between the base labels and the shared labels
-			const labelParts = formatLabels(labels, sharedLabels);
+			const labelParts = formatLabels(seriesLabels, sharedLabels);
 			if (sharedLabels !== undefined) {
 				// A histogram declared without label names still shares an empty
 				// object, and appending its flattened form would emit `{le="1",}`
@@ -96,7 +96,7 @@ class Registry {
 				}
 			}
 			const labelsString = labelParts.length ? `{${labelParts.join(',')}}` : '';
-			let fullMetricLine = `${metricName}${labelsString} ${getValueAsString(
+			let fullMetricLine = `${seriesName}${labelsString} ${getValueAsString(
 				val.value,
 			)}`;
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -70,7 +70,7 @@ class Registry {
 
 		for (const val of metric.values || []) {
 			let { metricName = name, labels = {} } = val;
-			const { sharedLabels = {} } = val;
+			const { sharedLabels } = val;
 			if (isOpenMetrics && metric.type === 'counter') {
 				metricName = `${metricName}_total`;
 			}
@@ -86,10 +86,15 @@ class Registry {
 
 			// We have to flatten these separately to avoid duplicate labels appearing
 			// between the base labels and the shared labels
-			const formattedLabels = formatLabels(labels, sharedLabels);
-
-			const flattenedShared = flattenSharedLabels(sharedLabels);
-			const labelParts = [...formattedLabels, flattenedShared].filter(Boolean);
+			const labelParts = formatLabels(labels, sharedLabels);
+			if (sharedLabels !== undefined) {
+				// A histogram declared without label names still shares an empty
+				// object, and appending its flattened form would emit `{le="1",}`
+				const flattenedShared = flattenSharedLabels(sharedLabels);
+				if (flattenedShared) {
+					labelParts.push(flattenedShared);
+				}
+			}
 			const labelsString = labelParts.length ? `{${labelParts.join(',')}}` : '';
 			let fullMetricLine = `${metricName}${labelsString} ${getValueAsString(
 				val.value,

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -461,6 +461,51 @@ describe('Register', () => {
 		describe('Registry with default labels', () => {
 			const Registry = require('../lib/registry');
 
+			it('should not emit a label twice when a default label name is also a shared label', async () => {
+				// Histogram buckets carry the series labels as shared labels; a default
+				// label of the same name must not be emitted alongside them. `env` does
+				// not collide, so it has to survive the merge.
+				const r = new Registry(regType);
+				r.setDefaultLabels({ route: 'default-route', env: 'production' });
+
+				const histogram = new Histogram({
+					name: 'my_histogram',
+					help: 'my histogram',
+					registers: [r],
+					labelNames: ['method', 'route'],
+					buckets: [1],
+				});
+				histogram.observe({ method: 'a"b\nc\\d', route: 'actual-route' }, 0.5);
+
+				const metrics = await r.metrics();
+
+				expect(metrics.split('\n')).toContain(
+					'my_histogram_bucket{le="1",env="production",method="a\\"b\\nc\\\\d",route="actual-route"} 1',
+				);
+				expect(metrics).not.toContain('default-route');
+			});
+
+			it('should treat only an absent sharedLabels as having none', async () => {
+				// `null` still reaches Object.entries and throws, as it did before the
+				// fast path. A truthiness check would render the series without them.
+				const r = new Registry(regType);
+				const values = [{ value: 1, labels: { a: '1' }, sharedLabels: null }];
+				r.registerMetric({
+					name: 'shared_null',
+					help: 'shared_null',
+					get() {
+						return {
+							name: 'shared_null',
+							help: 'shared_null',
+							type: 'gauge',
+							values,
+						};
+					},
+				});
+
+				await expect(r.metrics()).rejects.toThrow(TypeError);
+			});
+
 			describe('mutation tests', () => {
 				describe('registry.metrics()', () => {
 					it('should not throw with default labels (counter)', async () => {


### PR DESCRIPTION
Towards #800. You recommended landing the `formatLabels()` cleanup first, to see what it was worth on its own. I did not measure hoisting `exclude` to the caller separately, so treat that part as unmeasured. What I did measure is one level out.

`getMetricsAsString()` built the formatted labels, spread them into a second array along with the flattened shared labels, then filtered that into a third. The filter never filtered labels, because `formatLabels()` cannot return a falsy element, and the empty string from an empty flatten was the only thing it removed. A guard on the push does the same work with one array. That is where the time was.

Separately, `sharedLabels` was destructured with a `{}` default. Only Histogram sets the field, so every series of every other metric allocated that object, ran `Object.hasOwn` against it once per label, and handed `flattenSharedLabels()` a key its `WeakMap` would never see again. Branching on the field being absent skips all of it. A histogram declared without label names still shares an empty object, so it keeps the slow path; making Histogram omit it is a separate change.

Your sketch had `if (sharedLabels)` and I went with `!== undefined`. A collector passing `sharedLabels: null` throws on main, and the truthy test turns that into a silent render with the shared labels missing. Happy to switch if you would rather `null` render as no shared labels, it is a behaviour change either way and I kept main's.

The numbers are three reps of `npm run benchmarks` per Node major on 22, 24 and 26, median per case, against `trunk` at 1908ddb. On the registry `metrics()` cases this is 16%, 42 of 42 positive, +9% to +22%. Averaging the whole registry suite gives about 10%, since `getMetricsAsJSON()` is a third of those cases and cannot reach the change. Everything else in the harness sits at +0.07% median, 51 of 93 positive. Measured the same way, 623a74f is 4.9% and taking the helper out on its own is 4.2%, so removing the filter after that is the 12 points and the helper removal cost a little. faceoff's own verdicts on the run read `registry ⇒ metrics() no labels ⇒ current (1.24x faster)` and similar down the list.

The test is a histogram with two shared labels and a value that needs escaping. On main you can delete the dedup exclusion, or the escaping on shared label values, and all 551 tests still pass. Emitting only the first shared label is caught by one OpenMetrics snapshot in another file. The second test pins the `null` case, which nothing covered either.

I rendered 234 cases against main on both content types and compared hashes, covering 17 collector shapes including `null`, primitives and an object with a shadowed prototype. Identical byte for byte, down to which error is thrown and from where. Bypassing the deduplication moves the digest, so the comparison is not asleep.
