### PR TITLE
fix(default-metrics): register metrics alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This release marks our first release under the Prometheus umbrella.
 
 ### Changed
 
+- Register default metrics alphabetically
 - Allow `Pushgateway` to accept a custom registry as the second constructor argument
 - Add `Registry#getMetricsAsString()` to the TypeScript definitions
 - Improve types for no labels

--- a/lib/defaultMetrics.js
+++ b/lib/defaultMetrics.js
@@ -15,43 +15,43 @@
 'use strict';
 
 const { isObject } = require('./util');
+const { globalRegistry } = require('./registry');
 
 // Default metrics.
-const processCpuTotal = require('./metrics/processCpuTotal');
-const processStartTime = require('./metrics/processStartTime');
-const osMemoryHeap = require('./metrics/osMemoryHeap');
-const processOpenFileDescriptors = require('./metrics/processOpenFileDescriptors');
-const processMaxFileDescriptors = require('./metrics/processMaxFileDescriptors');
-const eventLoopLag = require('./metrics/eventLoopLag');
-const eventLoopUtilization = require('./metrics/eventLoopUtilization');
 const processHandles = require('./metrics/processHandles');
 const processRequests = require('./metrics/processRequests');
 const processResources = require('./metrics/processResources');
+const eventLoopLag = require('./metrics/eventLoopLag');
+const eventLoopUtilization = require('./metrics/eventLoopUtilization');
+const gc = require('./metrics/gc');
 const heapSizeAndUsed = require('./metrics/heapSizeAndUsed');
 const heapSpacesSizeAndUsed = require('./metrics/heapSpacesSizeAndUsed');
 const version = require('./metrics/version');
-const gc = require('./metrics/gc');
+const processCpuTotal = require('./metrics/processCpuTotal');
+const processMaxFileDescriptors = require('./metrics/processMaxFileDescriptors');
+const processOpenFileDescriptors = require('./metrics/processOpenFileDescriptors');
+const osMemoryHeap = require('./metrics/osMemoryHeap');
+const processStartTime = require('./metrics/processStartTime');
 
 const metrics = {
-	processCpuTotal,
-	processStartTime,
-	osMemoryHeap,
-	processOpenFileDescriptors,
-	processMaxFileDescriptors,
-	eventLoopLag,
-	eventLoopUtilization,
-
+	processHandles,
+	processRequests,
 	...(typeof process !== 'undefined' &&
 	// eslint-disable-next-line n/no-unsupported-features/node-builtins
 	typeof process.getActiveResourcesInfo === 'function'
 		? { processResources }
 		: {}),
-	processHandles,
-	processRequests,
+	eventLoopLag,
+	eventLoopUtilization,
+	gc,
 	heapSizeAndUsed,
 	heapSpacesSizeAndUsed,
 	version,
-	gc,
+	processCpuTotal,
+	processMaxFileDescriptors,
+	processOpenFileDescriptors,
+	osMemoryHeap,
+	processStartTime,
 };
 const metricsList = Object.keys(metrics);
 
@@ -61,9 +61,22 @@ module.exports = function collectDefaultMetrics(config) {
 	}
 
 	config = { eventLoopMonitoringPrecision: 10, ...config };
+	const register = config.register || globalRegistry;
+	const existingMetrics = new Set(register.getMetricsAsArray());
 
 	for (const metric of Object.values(metrics)) {
-		metric(config.register, config);
+		metric(register, config);
+	}
+
+	const defaultMetrics = register
+		.getMetricsAsArray()
+		.filter(metric => !existingMetrics.has(metric));
+	for (const metric of defaultMetrics) {
+		register.removeSingleMetric(metric.name);
+	}
+	defaultMetrics.sort((a, b) => a.name.localeCompare(b.name));
+	for (const metric of defaultMetrics) {
+		register.registerMetric(metric);
 	}
 };
 

--- a/lib/metrics/eventLoopLag.js
+++ b/lib/metrics/eventLoopLag.js
@@ -88,28 +88,14 @@ module.exports = (registry, config = {}) => {
 		}
 	}
 
-	const lag = new Gauge({
-		name: namePrefix + NODEJS_EVENTLOOP_LAG,
-		help: 'Lag of event loop in seconds.',
-		registers,
-		labelNames,
-		aggregator: 'average',
-		// Use this one metric's `collect` to set all metrics' values.
-		collect,
-	});
-	const lagMin = new Gauge({
-		name: namePrefix + NODEJS_EVENTLOOP_LAG_MIN,
-		help: 'The minimum recorded event loop delay.',
-		registers,
-		labelNames,
-		aggregator: 'min',
-	});
 	const lagMax = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_MAX,
 		help: 'The maximum recorded event loop delay.',
 		registers,
 		labelNames,
 		aggregator: 'max',
+		// Use this one metric's `collect` to set all metrics' values.
+		collect,
 	});
 	const lagMean = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_MEAN,
@@ -118,12 +104,12 @@ module.exports = (registry, config = {}) => {
 		labelNames,
 		aggregator: 'average',
 	});
-	const lagStddev = new Gauge({
-		name: namePrefix + NODEJS_EVENTLOOP_LAG_STDDEV,
-		help: 'The standard deviation of the recorded event loop delays.',
+	const lagMin = new Gauge({
+		name: namePrefix + NODEJS_EVENTLOOP_LAG_MIN,
+		help: 'The minimum recorded event loop delay.',
 		registers,
 		labelNames,
-		aggregator: 'average',
+		aggregator: 'min',
 	});
 	const lagP50 = new Gauge({
 		name: namePrefix + NODEJS_EVENTLOOP_LAG_P50,
@@ -146,15 +132,29 @@ module.exports = (registry, config = {}) => {
 		labelNames,
 		aggregator: 'average',
 	});
+	const lag = new Gauge({
+		name: namePrefix + NODEJS_EVENTLOOP_LAG,
+		help: 'Lag of event loop in seconds.',
+		registers,
+		labelNames,
+		aggregator: 'average',
+	});
+	const lagStddev = new Gauge({
+		name: namePrefix + NODEJS_EVENTLOOP_LAG_STDDEV,
+		help: 'The standard deviation of the recorded event loop delays.',
+		registers,
+		labelNames,
+		aggregator: 'average',
+	});
 };
 
 module.exports.metricNames = [
-	NODEJS_EVENTLOOP_LAG,
-	NODEJS_EVENTLOOP_LAG_MIN,
 	NODEJS_EVENTLOOP_LAG_MAX,
 	NODEJS_EVENTLOOP_LAG_MEAN,
-	NODEJS_EVENTLOOP_LAG_STDDEV,
+	NODEJS_EVENTLOOP_LAG_MIN,
 	NODEJS_EVENTLOOP_LAG_P50,
 	NODEJS_EVENTLOOP_LAG_P90,
 	NODEJS_EVENTLOOP_LAG_P99,
+	NODEJS_EVENTLOOP_LAG,
+	NODEJS_EVENTLOOP_LAG_STDDEV,
 ];

--- a/lib/metrics/eventLoopUtilization.js
+++ b/lib/metrics/eventLoopUtilization.js
@@ -1,16 +1,16 @@
 'use strict';
 
-const Summary = require('../summary');
 const Histogram = require('../histogram');
+const Summary = require('../summary');
 
 const { performance } = require('perf_hooks');
 
 // Reported always.
-const NODEJS_EVENTLOOP_UTILIZATION_SUMMARY =
-	'nodejs_eventloop_utilization_summary';
-
 const NODEJS_EVENTLOOP_UTILIZATION_HISTOGRAM =
 	'nodejs_eventloop_utilization_histogram';
+
+const NODEJS_EVENTLOOP_UTILIZATION_SUMMARY =
+	'nodejs_eventloop_utilization_summary';
 
 const DEFAULT_ELU_HISTOGRAM_BUCKETS = [
 	0.01, 0.05, 0.1, 0.25, 0.5, 0.6, 0.7, 0.75, 0.8, 0.9, 0.95, 0.99, 1,
@@ -28,6 +28,17 @@ module.exports = (registry, config = {}) => {
 	const labelNames = Object.keys(labels);
 	const registers = registry ? [registry] : undefined;
 
+	const buckets =
+		config.eventLoopUtilizationBuckets ?? DEFAULT_ELU_HISTOGRAM_BUCKETS;
+
+	const histogram = new Histogram({
+		name: namePrefix + NODEJS_EVENTLOOP_UTILIZATION_HISTOGRAM,
+		help: 'Ratio of time the event loop is not idling in the event provider to the total time the event loop is running.',
+		buckets,
+		registers,
+		labelNames,
+	});
+
 	const ageBuckets = config.eventLoopUtilizationAgeBuckets ?? 5;
 
 	const maxAgeSeconds = config.eventLoopUtilizationMaxAgeSeconds ?? 60;
@@ -41,17 +52,6 @@ module.exports = (registry, config = {}) => {
 		maxAgeSeconds,
 		ageBuckets,
 		percentiles,
-		registers,
-		labelNames,
-	});
-
-	const buckets =
-		config.eventLoopUtilizationBuckets ?? DEFAULT_ELU_HISTOGRAM_BUCKETS;
-
-	const histogram = new Histogram({
-		name: namePrefix + NODEJS_EVENTLOOP_UTILIZATION_HISTOGRAM,
-		help: 'Ratio of time the event loop is not idling in the event provider to the total time the event loop is running.',
-		buckets,
 		registers,
 		labelNames,
 	});
@@ -80,6 +80,6 @@ module.exports = (registry, config = {}) => {
 };
 
 module.exports.metricNames = [
-	NODEJS_EVENTLOOP_UTILIZATION_SUMMARY,
 	NODEJS_EVENTLOOP_UTILIZATION_HISTOGRAM,
+	NODEJS_EVENTLOOP_UTILIZATION_SUMMARY,
 ];

--- a/lib/metrics/heapSizeAndUsed.js
+++ b/lib/metrics/heapSizeAndUsed.js
@@ -17,9 +17,9 @@
 const Gauge = require('../gauge');
 const safeMemoryUsage = require('./helpers/safeMemoryUsage');
 
+const NODEJS_EXTERNAL_MEMORY = 'nodejs_external_memory_bytes';
 const NODEJS_HEAP_SIZE_TOTAL = 'nodejs_heap_size_total_bytes';
 const NODEJS_HEAP_SIZE_USED = 'nodejs_heap_size_used_bytes';
-const NODEJS_EXTERNAL_MEMORY = 'nodejs_external_memory_bytes';
 
 module.exports = (registry, config = {}) => {
 	if (typeof process.memoryUsage !== 'function') {
@@ -41,13 +41,19 @@ module.exports = (registry, config = {}) => {
 		}
 	};
 
+	const externalMemUsed = new Gauge({
+		name: namePrefix + NODEJS_EXTERNAL_MEMORY,
+		help: 'Node.js external memory size in bytes.',
+		registers,
+		labelNames,
+		// Use this one metric's `collect` to set all metrics' values.
+		collect,
+	});
 	const heapSizeTotal = new Gauge({
 		name: namePrefix + NODEJS_HEAP_SIZE_TOTAL,
 		help: 'Process heap size from Node.js in bytes.',
 		registers,
 		labelNames,
-		// Use this one metric's `collect` to set all metrics' values.
-		collect,
 	});
 	const heapSizeUsed = new Gauge({
 		name: namePrefix + NODEJS_HEAP_SIZE_USED,
@@ -55,16 +61,10 @@ module.exports = (registry, config = {}) => {
 		registers,
 		labelNames,
 	});
-	const externalMemUsed = new Gauge({
-		name: namePrefix + NODEJS_EXTERNAL_MEMORY,
-		help: 'Node.js external memory size in bytes.',
-		registers,
-		labelNames,
-	});
 };
 
 module.exports.metricNames = [
+	NODEJS_EXTERNAL_MEMORY,
 	NODEJS_HEAP_SIZE_TOTAL,
 	NODEJS_HEAP_SIZE_USED,
-	NODEJS_EXTERNAL_MEMORY,
 ];

--- a/lib/metrics/heapSpacesSizeAndUsed.js
+++ b/lib/metrics/heapSpacesSizeAndUsed.js
@@ -17,7 +17,7 @@
 const Gauge = require('../gauge');
 const v8 = require('v8');
 
-const METRICS = ['total', 'used', 'available'];
+const METRICS = ['available', 'total', 'used'];
 const NODEJS_HEAP_SIZE = {};
 
 METRICS.forEach(metricType => {
@@ -51,7 +51,7 @@ module.exports = (registry, config = {}) => {
 	});
 
 	// Use this one metric's `collect` to set all metrics' values.
-	gauges.total.collect = () => {
+	gauges.available.collect = () => {
 		for (const space of v8.getHeapSpaceStatistics()) {
 			const spaceName = space.space_name.substr(
 				0,

--- a/lib/metrics/osMemoryHeapLinux.js
+++ b/lib/metrics/osMemoryHeapLinux.js
@@ -22,9 +22,9 @@ const debug = debuglog('prom:metrics:os-memory-heap-linux');
 
 const values = ['VmSize', 'VmRSS', 'VmData'];
 
+const PROCESS_HEAP = 'process_heap_bytes';
 const PROCESS_RESIDENT_MEMORY = 'process_resident_memory_bytes';
 const PROCESS_VIRTUAL_MEMORY = 'process_virtual_memory_bytes';
-const PROCESS_HEAP = 'process_heap_bytes';
 
 function structureOutput(input) {
 	return input.split('\n').reduce((acc, string) => {
@@ -53,9 +53,9 @@ module.exports = (registry, config = {}) => {
 	const labels = config.labels ? config.labels : {};
 	const labelNames = Object.keys(labels);
 
-	const residentMemGauge = new Gauge({
-		name: namePrefix + PROCESS_RESIDENT_MEMORY,
-		help: 'Resident memory size in bytes.',
+	const heapSizeMemGauge = new Gauge({
+		name: namePrefix + PROCESS_HEAP,
+		help: 'Process heap size in bytes.',
 		registers,
 		labelNames,
 		// Use this one metric's `collect` to set all metrics' values.
@@ -78,22 +78,22 @@ module.exports = (registry, config = {}) => {
 			}
 		},
 	});
+	const residentMemGauge = new Gauge({
+		name: namePrefix + PROCESS_RESIDENT_MEMORY,
+		help: 'Resident memory size in bytes.',
+		registers,
+		labelNames,
+	});
 	const virtualMemGauge = new Gauge({
 		name: namePrefix + PROCESS_VIRTUAL_MEMORY,
 		help: 'Virtual memory size in bytes.',
 		registers,
 		labelNames,
 	});
-	const heapSizeMemGauge = new Gauge({
-		name: namePrefix + PROCESS_HEAP,
-		help: 'Process heap size in bytes.',
-		registers,
-		labelNames,
-	});
 };
 
 module.exports.metricNames = [
+	PROCESS_HEAP,
 	PROCESS_RESIDENT_MEMORY,
 	PROCESS_VIRTUAL_MEMORY,
-	PROCESS_HEAP,
 ];

--- a/lib/metrics/processCpuTotal.js
+++ b/lib/metrics/processCpuTotal.js
@@ -17,9 +17,9 @@
 const OtelApi = require('@opentelemetry/api');
 const Counter = require('../counter');
 
-const PROCESS_CPU_USER_SECONDS = 'process_cpu_user_seconds_total';
-const PROCESS_CPU_SYSTEM_SECONDS = 'process_cpu_system_seconds_total';
 const PROCESS_CPU_SECONDS = 'process_cpu_seconds_total';
+const PROCESS_CPU_SYSTEM_SECONDS = 'process_cpu_system_seconds_total';
+const PROCESS_CPU_USER_SECONDS = 'process_cpu_user_seconds_total';
 
 module.exports = (registry, config = {}) => {
 	const registers = registry ? [registry] : undefined;
@@ -30,9 +30,9 @@ module.exports = (registry, config = {}) => {
 
 	let lastCpuUsage = process.cpuUsage();
 
-	const cpuUserUsageCounter = new Counter({
-		name: namePrefix + PROCESS_CPU_USER_SECONDS,
-		help: 'Total user CPU time spent in seconds.',
+	const cpuUsageCounter = new Counter({
+		name: namePrefix + PROCESS_CPU_SECONDS,
+		help: 'Total user and system CPU time spent in seconds.',
 		enableExemplars: exemplars,
 		registers,
 		labelNames,
@@ -86,9 +86,9 @@ module.exports = (registry, config = {}) => {
 		registers,
 		labelNames,
 	});
-	const cpuUsageCounter = new Counter({
-		name: namePrefix + PROCESS_CPU_SECONDS,
-		help: 'Total user and system CPU time spent in seconds.',
+	const cpuUserUsageCounter = new Counter({
+		name: namePrefix + PROCESS_CPU_USER_SECONDS,
+		help: 'Total user CPU time spent in seconds.',
 		enableExemplars: exemplars,
 		registers,
 		labelNames,
@@ -96,7 +96,7 @@ module.exports = (registry, config = {}) => {
 };
 
 module.exports.metricNames = [
-	PROCESS_CPU_USER_SECONDS,
-	PROCESS_CPU_SYSTEM_SECONDS,
 	PROCESS_CPU_SECONDS,
+	PROCESS_CPU_SYSTEM_SECONDS,
+	PROCESS_CPU_USER_SECONDS,
 ];

--- a/test/defaultMetricsTest.js
+++ b/test/defaultMetricsTest.js
@@ -66,6 +66,34 @@ describe.each([
 		expect(await register.getMetricsAsJSON()).not.toHaveLength(0);
 	});
 
+	it('should register metric groups alphabetically', () => {
+		expect(collectDefaultMetrics.metricsList).toEqual([
+			'processHandles',
+			'processRequests',
+			'processResources',
+			'eventLoopLag',
+			'eventLoopUtilization',
+			'gc',
+			'heapSizeAndUsed',
+			'heapSpacesSizeAndUsed',
+			'version',
+			'processCpuTotal',
+			'processMaxFileDescriptors',
+			'processOpenFileDescriptors',
+			'osMemoryHeap',
+			'processStartTime',
+		]);
+	});
+
+	it('should register metrics alphabetically', async () => {
+		collectDefaultMetrics();
+		const metricNames = (await register.getMetricsAsJSON()).map(
+			metric => metric.name,
+		);
+
+		expect(metricNames).toEqual(metricNames.toSorted());
+	});
+
 	it('should allow blacklisting all metrics', async () => {
 		expect(await register.getMetricsAsJSON()).toHaveLength(0);
 		clearInterval(collectDefaultMetrics());

--- a/test/metrics/eventLoopLagTest.js
+++ b/test/metrics/eventLoopLagTest.js
@@ -44,47 +44,47 @@ describe.each([
 		const metrics = await register.getMetricsAsJSON();
 		expect(metrics).toHaveLength(8);
 
-		expect(metrics[0].help).toEqual('Lag of event loop in seconds.');
+		expect(metrics[0].help).toEqual('The maximum recorded event loop delay.');
 		expect(metrics[0].type).toEqual('gauge');
-		expect(metrics[0].name).toEqual('nodejs_eventloop_lag_seconds');
+		expect(metrics[0].name).toEqual('nodejs_eventloop_lag_max_seconds');
 
-		expect(metrics[1].help).toEqual('The minimum recorded event loop delay.');
-		expect(metrics[1].type).toEqual('gauge');
-		expect(metrics[1].name).toEqual('nodejs_eventloop_lag_min_seconds');
-
-		expect(metrics[2].help).toEqual('The maximum recorded event loop delay.');
-		expect(metrics[2].type).toEqual('gauge');
-		expect(metrics[2].name).toEqual('nodejs_eventloop_lag_max_seconds');
-
-		expect(metrics[3].help).toEqual(
+		expect(metrics[1].help).toEqual(
 			'The mean of the recorded event loop delays.',
 		);
-		expect(metrics[3].type).toEqual('gauge');
-		expect(metrics[3].name).toEqual('nodejs_eventloop_lag_mean_seconds');
+		expect(metrics[1].type).toEqual('gauge');
+		expect(metrics[1].name).toEqual('nodejs_eventloop_lag_mean_seconds');
 
-		expect(metrics[4].help).toEqual(
-			'The standard deviation of the recorded event loop delays.',
-		);
-		expect(metrics[4].type).toEqual('gauge');
-		expect(metrics[4].name).toEqual('nodejs_eventloop_lag_stddev_seconds');
+		expect(metrics[2].help).toEqual('The minimum recorded event loop delay.');
+		expect(metrics[2].type).toEqual('gauge');
+		expect(metrics[2].name).toEqual('nodejs_eventloop_lag_min_seconds');
 
-		expect(metrics[5].help).toEqual(
+		expect(metrics[3].help).toEqual(
 			'The 50th percentile of the recorded event loop delays.',
 		);
-		expect(metrics[5].type).toEqual('gauge');
-		expect(metrics[5].name).toEqual('nodejs_eventloop_lag_p50_seconds');
+		expect(metrics[3].type).toEqual('gauge');
+		expect(metrics[3].name).toEqual('nodejs_eventloop_lag_p50_seconds');
 
-		expect(metrics[6].help).toEqual(
+		expect(metrics[4].help).toEqual(
 			'The 90th percentile of the recorded event loop delays.',
 		);
-		expect(metrics[6].type).toEqual('gauge');
-		expect(metrics[6].name).toEqual('nodejs_eventloop_lag_p90_seconds');
+		expect(metrics[4].type).toEqual('gauge');
+		expect(metrics[4].name).toEqual('nodejs_eventloop_lag_p90_seconds');
 
-		expect(metrics[7].help).toEqual(
+		expect(metrics[5].help).toEqual(
 			'The 99th percentile of the recorded event loop delays.',
 		);
+		expect(metrics[5].type).toEqual('gauge');
+		expect(metrics[5].name).toEqual('nodejs_eventloop_lag_p99_seconds');
+
+		expect(metrics[6].help).toEqual('Lag of event loop in seconds.');
+		expect(metrics[6].type).toEqual('gauge');
+		expect(metrics[6].name).toEqual('nodejs_eventloop_lag_seconds');
+
+		expect(metrics[7].help).toEqual(
+			'The standard deviation of the recorded event loop delays.',
+		);
 		expect(metrics[7].type).toEqual('gauge');
-		expect(metrics[7].name).toEqual('nodejs_eventloop_lag_p99_seconds');
+		expect(metrics[7].name).toEqual('nodejs_eventloop_lag_stddev_seconds');
 	});
 });
 

--- a/test/metrics/eventLoopUtilizationTest.js
+++ b/test/metrics/eventLoopUtilizationTest.js
@@ -30,7 +30,7 @@ describe('eventLoopUtilization', () => {
 		{
 			const percentilesCount = 7;
 
-			const eluSummaryMetric = metrics[0];
+			const eluSummaryMetric = metrics[1];
 			expect(eluSummaryMetric.type).toEqual('summary');
 			expect(eluSummaryMetric.name).toEqual(
 				'nodejs_eventloop_utilization_summary',
@@ -57,7 +57,7 @@ describe('eventLoopUtilization', () => {
 		{
 			const bucketsCount = 14;
 
-			const eluHistogramMetric = metrics[1];
+			const eluHistogramMetric = metrics[0];
 			expect(eluHistogramMetric.type).toEqual('histogram');
 			expect(eluHistogramMetric.name).toEqual(
 				'nodejs_eventloop_utilization_histogram',

--- a/test/metrics/heapSizeAndUsedTest.js
+++ b/test/metrics/heapSizeAndUsedTest.js
@@ -39,8 +39,13 @@ describe.each([
 		};
 
 		heapSizeAndUsed();
-		// Note: these three gauges' values are set by the _total gauge's
+		// Note: these three gauges' values are set by the _external gauge's
 		// "collect" function.
+
+		const externalGauge = globalRegistry.getSingleMetric(
+			'nodejs_external_memory_bytes',
+		);
+		expect((await externalGauge.get()).values[0].value).toEqual(100);
 
 		const totalGauge = globalRegistry.getSingleMetric(
 			'nodejs_heap_size_total_bytes',
@@ -51,10 +56,5 @@ describe.each([
 			'nodejs_heap_size_used_bytes',
 		);
 		expect((await usedGauge.get()).values[0].value).toEqual(500);
-
-		const externalGauge = globalRegistry.getSingleMetric(
-			'nodejs_external_memory_bytes',
-		);
-		expect((await externalGauge.get()).values[0].value).toEqual(100);
 	});
 });

--- a/test/metrics/heapSpacesSizeAndUsedTest.js
+++ b/test/metrics/heapSpacesSizeAndUsedTest.js
@@ -83,8 +83,17 @@ describe.each([
 
 		const metrics = await globalRegistry.getMetricsAsJSON();
 
-		expect(metrics[0].name).toEqual('nodejs_heap_space_size_total_bytes');
+		expect(metrics[0].name).toEqual('nodejs_heap_space_size_available_bytes');
 		expect(metrics[0].values).toEqual([
+			{ labels: { space: 'new' }, value: 500 },
+			{ labels: { space: 'old' }, value: 500 },
+			{ labels: { space: 'code' }, value: 500 },
+			{ labels: { space: 'map' }, value: 500 },
+			{ labels: { space: 'large_object' }, value: 500 },
+		]);
+
+		expect(metrics[1].name).toEqual('nodejs_heap_space_size_total_bytes');
+		expect(metrics[1].values).toEqual([
 			{ labels: { space: 'new' }, value: 100 },
 			{ labels: { space: 'old' }, value: 100 },
 			{ labels: { space: 'code' }, value: 100 },
@@ -92,22 +101,13 @@ describe.each([
 			{ labels: { space: 'large_object' }, value: 100 },
 		]);
 
-		expect(metrics[1].name).toEqual('nodejs_heap_space_size_used_bytes');
-		expect(metrics[1].values).toEqual([
+		expect(metrics[2].name).toEqual('nodejs_heap_space_size_used_bytes');
+		expect(metrics[2].values).toEqual([
 			{ labels: { space: 'new' }, value: 50 },
 			{ labels: { space: 'old' }, value: 50 },
 			{ labels: { space: 'code' }, value: 50 },
 			{ labels: { space: 'map' }, value: 50 },
 			{ labels: { space: 'large_object' }, value: 50 },
-		]);
-
-		expect(metrics[2].name).toEqual('nodejs_heap_space_size_available_bytes');
-		expect(metrics[2].values).toEqual([
-			{ labels: { space: 'new' }, value: 500 },
-			{ labels: { space: 'old' }, value: 500 },
-			{ labels: { space: 'code' }, value: 500 },
-			{ labels: { space: 'map' }, value: 500 },
-			{ labels: { space: 'large_object' }, value: 500 },
 		]);
 	});
 });


### PR DESCRIPTION
Default metrics currently follow collector registration order, so the output is not ordered by metric name.

This reorders metric groups and metrics inside multi-metric collectors where needed. Shared `collect()` callbacks move to the first registered metric so sibling values are populated before the registry reads them.

Collectors such as `heapSizeAndUsed` register names under more than one prefix, so object order alone cannot produce a globally sorted result. `collectDefaultMetrics()` therefore sorts only the newly registered default metrics once after registration. Existing custom metrics keep their registration order.

Tests:

- `npm test`
- `bun test-unit`

Fixes #810.