### PR TITLE
Don't zero out Gauges. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Breaking
 
+- Gauges no longer initialize to zero, even if they have no labels
+- `reset()` changes that may require modifications to custom Metrics:
+  - it is no longer called in the middle of the constructor
+  - it now defaults to clearing the labelMap
+
 ### Changed
 
 - Organized default metrics

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -18,7 +18,7 @@
 'use strict';
 
 const util = require('util');
-const { isObject, getLabels, nowTimestamp, LabelMap } = require('./util');
+const { isObject, getLabels, nowTimestamp } = require('./util');
 const { Metric } = require('./metric');
 const Exemplar = require('./exemplar');
 
@@ -34,6 +34,10 @@ class Counter extends Metric {
 			this.inc = this.incWithExemplar;
 		} else {
 			this.inc = this.incWithoutExemplar;
+		}
+
+		if (this.labelNames.length === 0) {
+			this.store.set({}, 0);
 		}
 	}
 
@@ -102,7 +106,8 @@ class Counter extends Metric {
 	 * @returns {void}
 	 */
 	reset() {
-		this.store = new LabelMap(this.labelNames);
+		this.store.clear();
+
 		if (this.labelNames.length === 0) {
 			this.store.set({}, 0);
 		}

--- a/lib/gauge.js
+++ b/lib/gauge.js
@@ -19,7 +19,7 @@
 
 const util = require('util');
 
-const { getLabels, isObject, LabelMap } = require('./util');
+const { getLabels, isObject } = require('./util');
 const { Metric } = require('./metric');
 
 class Gauge extends Metric {
@@ -38,17 +38,6 @@ class Gauge extends Metric {
 		value = getValueArg(labels, value);
 		labels = getLabelArg(labels);
 		set(this, labels, value);
-	}
-
-	/**
-	 * Reset gauge.
-	 * @returns {void}
-	 */
-	reset() {
-		this.store = new LabelMap(this.labelNames);
-		if (this.labelNames.length === 0) {
-			this.store.set({}, 0);
-		}
 	}
 
 	/**

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -134,10 +134,6 @@ class Histogram extends Metric {
 		};
 	}
 
-	reset() {
-		this.store = new LabelMap(this.labelNames);
-	}
-
 	/**
 	 * Initialize the metrics for the given combination of labels to zero.
 	 * @param {object} labels - Object with labels where key is the label key and value is label value. Can only be one level deep

--- a/lib/metric.js
+++ b/lib/metric.js
@@ -15,7 +15,7 @@
 'use strict';
 
 const Registry = require('./registry');
-const { isObject } = require('./util');
+const { isObject, LabelMap } = require('./util');
 const { validateMetricName, validateLabelName } = require('./validation');
 
 /**
@@ -67,8 +67,7 @@ class Metric {
 			this.sortedLabelNames = [];
 		}
 
-		// TODO: Bad things happen when you call functions on half-initialized objects, yo
-		this.reset();
+		this.store = new LabelMap(this.labelNames);
 
 		for (const register of this.registers) {
 			if (
@@ -83,8 +82,12 @@ class Metric {
 		}
 	}
 
+	/**
+	 * Reset the metric.
+	 * @returns {void}
+	 */
 	reset() {
-		/* abstract */
+		this.store.clear();
 	}
 }
 

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -18,7 +18,7 @@
 'use strict';
 
 const util = require('util');
-const { getLabels, LabelMap } = require('./util');
+const { getLabels } = require('./util');
 const { Metric } = require('./metric');
 const timeWindowQuantiles = require('./timeWindowQuantiles');
 
@@ -29,24 +29,22 @@ class Summary extends Metric {
 		super(config, {
 			percentiles: [0.01, 0.05, 0.5, 0.9, 0.95, 0.99, 0.999],
 			compressCount: DEFAULT_COMPRESS_COUNT,
-			store: new LabelMap(),
 		});
 
-		if (this.labelNames.includes('quantile'))
-			throw new Error('quantile is a reserved label keyword');
-
 		this.type = 'summary';
-		this.store = new LabelMap(this.labelNames);
+
+		if (this.labelNames.includes('quantile')) {
+			throw new Error('quantile is a reserved label keyword');
+		}
 
 		if (this.labelNames.length === 0) {
-			this.store.set(
-				{},
-				{
-					td: new timeWindowQuantiles(this.maxAgeSeconds, this.ageBuckets),
-					count: 0,
-					sum: 0,
-				},
-			);
+			const initial = {
+				td: new timeWindowQuantiles(this.maxAgeSeconds, this.ageBuckets),
+				count: 0,
+				sum: 0,
+			};
+
+			this.store.set({}, initial);
 		}
 	}
 

--- a/test/__snapshots__/registerTest.js.snap
+++ b/test/__snapshots__/registerTest.js.snap
@@ -32,7 +32,6 @@ exports[`Register with OpenMetrics type should output all initialized metrics at
 counter_total 0
 # HELP gauge help
 # TYPE gauge gauge
-gauge 0
 # HELP histogram help
 # TYPE histogram histogram
 histogram_bucket{le="0.005"} 0
@@ -86,7 +85,6 @@ counter 0
 
 # HELP gauge help
 # TYPE gauge gauge
-gauge 0
 
 # HELP histogram help
 # TYPE histogram histogram

--- a/test/gaugeTest.js
+++ b/test/gaugeTest.js
@@ -138,12 +138,13 @@ describe.each([
 				expect(fn).toThrowErrorMatchingSnapshot();
 			});
 
-			it('should init to 0', async () => {
+			it('should not init to 0', async () => {
 				instance = new Gauge({
 					name: 'init_gauge',
 					help: 'somehelp',
 				});
-				await expectValue(0);
+
+				await expect(instance.get()).resolves.toBeEmpty;
 			});
 
 			describe('with labels', () => {
@@ -287,6 +288,7 @@ describe.each([
 		afterEach(() => {
 			globalRegistry.clear();
 		});
+
 		it('should reset labelless gauge', async () => {
 			const instance = new Gauge({
 				name: 'test_metric',
@@ -297,7 +299,7 @@ describe.each([
 			expect((await instance.get()).values[0].value).toEqual(12);
 
 			instance.reset();
-			expect((await instance.get()).values[0].value).toEqual(0);
+			expect(await instance.get()).toBeEmpty;
 
 			instance.set(10);
 			expect((await instance.get()).values[0].value).toEqual(10);

--- a/test/metricTest.js
+++ b/test/metricTest.js
@@ -53,7 +53,7 @@ describe('Metric', () => {
 		).toThrow(new Error('Optional "collect" parameter must be a function'));
 	});
 
-	it('applies defaults, sorts labels, and resets on construction', () => {
+	it('applies defaults, sorts labels on construction', () => {
 		const collect = jest.fn();
 		const metric = new TestMetric({
 			name: 'test_metric',
@@ -68,7 +68,6 @@ describe('Metric', () => {
 			collect,
 			enableExemplars: false,
 			labelNames: ['status', 'method'],
-			resetCalls: 1,
 			sortedLabelNames: ['method', 'status'],
 		});
 	});


### PR DESCRIPTION
This PR started as exploratory work for a different issue - there's been a TODO that I added to metric.js that fights the work needed for #812. I had already decided that doing #812 all in a single PR would probably get a little bit on the long side, so I was looking for some stopping point in the middle to split it up.

I noticed that if #622 were fixed, then a default `reset()` implementation would be used by 2 of the 4 builtin metric types.

This PR initializes the store in metrics.js, and then retains the LabelMap object across `reset()` calls, and removes the zeroing logic from `Gauge.reset()`, thereby fixing #622.