### PR TITLE
perf(histogram): render the export list straight from the store iterator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Organized default metrics
+- perf: Histogram rendering builds its export list straight from the store iterator instead of an intermediate array. Faster at high series counts on Node 24 and 26, can be slightly slower on Node 22
 
 ### Added
 

--- a/benchmarks/histogram.js
+++ b/benchmarks/histogram.js
@@ -14,7 +14,11 @@
 
 'use strict';
 
-const { getLabelNames, labelCombinationFactory } = require('./utils/labels');
+const {
+	getLabelNames,
+	getLabelCombinations,
+	labelCombinationFactory,
+} = require('./utils/labels');
 
 module.exports = setupHistogramSuite;
 
@@ -100,6 +104,19 @@ function setupHistogramSuite(suite) {
 		),
 		{ teardown, setup: setup(6) },
 	);
+
+	// `method` repeats `delete`, so `1 x 64` stores 63 label sets and `2 x 8` stores 56.
+	[
+		{ name: 'no labels', counts: [] },
+		{ name: '1 x 64', counts: [64] },
+		{ name: '2 x 8', counts: [8, 8] },
+		{ name: '6 x 2', counts: [2, 2, 2, 2, 2, 2] },
+	].forEach(({ name, counts }) => {
+		suite.add(`get() ${name}`, (client, { histogram }) => histogram.get(), {
+			teardown,
+			setup: observed(counts),
+		});
+	});
 }
 
 function setup(labelCount) {
@@ -112,6 +129,25 @@ function setup(labelCount) {
 			labelNames: getLabelNames(labelCount),
 			registers: [registry],
 		});
+
+		return { registry, histogram };
+	};
+}
+
+function observed(labelCounts) {
+	return client => {
+		const registry = new client.Registry();
+
+		const histogram = new client.Histogram({
+			name: 'histogram',
+			help: 'histogram',
+			labelNames: getLabelNames(labelCounts.length),
+			registers: [registry],
+		});
+
+		getLabelCombinations(labelCounts).forEach(labels =>
+			histogram.observe({ ...labels }, 1),
+		);
 
 		return { registry, histogram };
 	};

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -120,8 +120,8 @@ class Histogram extends Metric {
 			const v = this.collect();
 			if (v instanceof Promise) await v;
 		}
-		const data = Array.from(this.store.values());
-		const values = data
+		const values = this.store
+			.values()
 			.map(extractBucketValuesForExport(this))
 			.reduce(addSumAndCountForExport(this), []);
 


### PR DESCRIPTION
The Array.from cleanup you suggested after #804. Only one call site qualified. LabelMap.values() hands back the raw Map iterator, so the histogram export can map and reduce over it directly and both intermediate arrays go away. The other Array.from uses in lib feed the public API, which is typed as real arrays, or sit on cold paths, so I left those alone.

Measurements are in my earlier comment at https://github.com/prometheus/client_js/pull/804#issuecomment-5306535878. It helps 24 and 26 at high series counts and can cost a few percent on 22 under default heap settings. You called that acceptable for a major release with a note, so the CHANGELOG entry says exactly that.

I verified the rendered output is byte identical to main on 22, 24 and 26, and the suite passes on all three.
