### PR TITLE
test: fix BroadcastChannel leakage in worker.js test suite

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -46,6 +46,7 @@ let requestCtr = 0; // Concurrency control
 const requests = new Map(); // Pending requests for workers' local metrics.
 const workers = new Map();
 let historicMetrics = []; // Metrics from dead workers
+let ownChannel; // This thread's own broadcast channel, set once listeners are added.
 
 class WorkerRegistry extends Registry {
 	/**
@@ -232,6 +233,36 @@ class WorkerRegistry extends Registry {
 	}
 
 	/**
+	 * Close every channel and listener opened by this module instance.
+	 *
+	 * `BroadcastChannel`s created here keep receiving messages until closed,
+	 * even once nothing in JS still references them. Test suites that call
+	 * `jest.resetModules()` between cases therefore need this to release the
+	 * previous instance's channels; otherwise its listeners keep reacting to
+	 * later tests' messages on the same channel names. Not for production use.
+	 * @returns {void}
+	 */
+	static resetForTesting() {
+		if (!['test', 'development'].includes(process.env.NODE_ENV)) {
+			throw new Error(
+				'WorkerRegistry.resetForTesting() is only available in test or development mode.',
+			);
+		}
+
+		ANNOUNCEMENT_CHANNEL.close();
+		ownChannel?.close();
+
+		for (const entry of workers.values()) {
+			entry.channel.close();
+		}
+
+		workers.clear();
+		requests.clear();
+		historicMetrics = [];
+		listenersAdded = false;
+	}
+
+	/**
 	 * Sets the registry or registries to be aggregated. Call from workers to
 	 * use a registry/registries other than the default global registry.
 	 * @param {Array<Registry>|Registry} regs Registry or registries to be
@@ -264,7 +295,7 @@ function addListeners(primary) {
 	}
 
 	const name = `@prometheus-io/client:worker:${threadId}`;
-	const channel = new BroadcastChannel(name).unref();
+	ownChannel = new BroadcastChannel(name).unref();
 
 	ANNOUNCEMENT_CHANNEL.addEventListener('message', async event => {
 		const message = event.data;
@@ -279,7 +310,7 @@ function addListeners(primary) {
 			);
 
 			try {
-				channel.postMessage({
+				ownChannel.postMessage({
 					type: GET_METRICS_RES,
 					requestId: message.requestId,
 					threadId,
@@ -287,7 +318,7 @@ function addListeners(primary) {
 				});
 			} catch (error) {
 				debug(error);
-				channel.postMessage({
+				ownChannel.postMessage({
 					type: GET_METRICS_RES,
 					requestId: message.requestId,
 					error: error.message,
@@ -298,7 +329,7 @@ function addListeners(primary) {
 		}
 	});
 
-	channel.addEventListener('message', async event => {
+	ownChannel.addEventListener('message', async event => {
 		const message = event.data;
 
 		if (message.type === ACK) {

--- a/test/workerTest.js
+++ b/test/workerTest.js
@@ -44,10 +44,15 @@ describe.each([
 
 	describe('WorkerRegistry.workerMetrics()', () => {
 		it('works properly if there are no workers', async () => {
+			jest.resetModules();
 			const WorkerRegistry = require('../lib/worker');
 			const registry = new WorkerRegistry(regType);
-			const metrics = await registry.workerMetrics();
-			expect(metrics).toEqual('');
+			try {
+				const metrics = await registry.workerMetrics();
+				expect(metrics).toEqual('');
+			} finally {
+				WorkerRegistry.resetForTesting();
+			}
 		});
 
 		it('aggregates worker responses in thread id order', async () => {
@@ -57,14 +62,6 @@ describe.each([
 			const announcementChannel = new BroadcastChannel(
 				'@prometheus-io/client:announce',
 			).unref();
-
-			const discovery = new Promise(resolve => {
-				announcementChannel.addEventListener('message', async event => {
-					if (event.data.type === ANNOUNCEMENT && !event.data.primary) {
-						resolve(event);
-					}
-				});
-			});
 
 			const responders = [1, 2, 3].map(threadId => {
 				const name = `@prometheus-io/client:worker:${threadId}`;
@@ -79,7 +76,13 @@ describe.each([
 				return { threadId, channel };
 			});
 
-			await discovery; // Let announcements arrive
+			// Wait for the primary to register all 3 fake workers, rather than
+			// hoping to catch a message announcing it: a self-posted message on
+			// announcementChannel is never delivered back to announcementChannel
+			// itself, so nothing here guarantees an observable echo.
+			while (AggregatorRegistry.workerCount() < responders.length) {
+				await delay(1);
+			}
 
 			let finishSendingResponses;
 			const responsesSent = new Promise(resolve => {
@@ -111,6 +114,7 @@ describe.each([
 			} finally {
 				announcementChannel.close();
 				for (const responder of responders) responder.channel.close();
+				AggregatorRegistry.resetForTesting();
 			}
 		});
 
@@ -156,6 +160,7 @@ describe.each([
 			} finally {
 				announcementChannel.close();
 				channel.close();
+				AggregatorRegistry.resetForTesting();
 			}
 		});
 	});
@@ -164,7 +169,6 @@ describe.each([
 		let AggregatorRegistry;
 		let announcementChannel;
 		let registry;
-		let discovery;
 
 		beforeEach(async () => {
 			jest.resetModules();
@@ -175,18 +179,11 @@ describe.each([
 			).unref();
 
 			registry = new AggregatorRegistry(regType);
-
-			discovery = new Promise(resolve => {
-				announcementChannel.addEventListener('message', async event => {
-					if (event.data.type === ANNOUNCEMENT && !event.data.primary) {
-						resolve(event);
-					}
-				});
-			});
 		});
 
 		afterEach(() => {
 			announcementChannel.close();
+			AggregatorRegistry.resetForTesting();
 		});
 
 		it('returns immediately on no outstanding requests', async () => {
@@ -194,6 +191,10 @@ describe.each([
 		});
 
 		it('sends data back to the primary', async () => {
+			// The beforeEach above set this instance up as the primary; tear it
+			// down before loading a fresh one to act as the worker instead, so
+			// the primary's channels don't leak into later tests.
+			AggregatorRegistry.resetForTesting();
 			jest.resetModules();
 			AggregatorRegistry = require('../lib/worker');
 
@@ -262,7 +263,13 @@ describe.each([
 					}
 				});
 
-				await discovery;
+				// Wait for the primary to register this fake worker, rather than
+				// hoping to catch a message announcing it: a self-posted message on
+				// announcementChannel is never delivered back to announcementChannel
+				// itself, so nothing here guarantees an observable echo.
+				while (AggregatorRegistry.workerCount() < 1) {
+					await delay(1);
+				}
 			});
 
 			afterEach(() => {
@@ -287,6 +294,7 @@ describe.each([
 
 				const AggregatorRegistry = require('../lib/worker');
 				const ar = new AggregatorRegistry(regType);
+				AggregatorRegistry.resetForTesting();
 			}
 		});
 
@@ -318,7 +326,9 @@ describe.each([
 			try {
 				expect(() => channel.postMessage(unexpected)).not.toThrow();
 			} finally {
+				announcementChannel.close();
 				channel.close();
+				WorkerRegistry.resetForTesting();
 			}
 		});
 	});


### PR DESCRIPTION
## What

Follow-up to #806. While reviewing that PR, `test/workerTest.js`'s "aggregates worker responses in thread id order" and two `shutdown()` tests turned out to only pass by accident: `jest.resetModules()` creates a fresh `WorkerRegistry` module instance per test, each with its own `ANNOUNCEMENT_CHANNEL` and per-thread `BroadcastChannel`. Those channels keep receiving messages until explicitly closed — even once nothing in JS still references them — so a previous test's listeners stayed alive and kept reacting to later tests' messages on the same channel names.

That leakage is exactly what let those three tests pass at all: their `discovery` promise, which waits for a non-primary `ANNOUNCEMENT` echo, only ever resolved via a stray listener left over from an earlier test — never from anything the test itself set up. Run any of the three in true isolation (`-t "..."`) against `main` and they fail outright (timeout or `InvalidStateError: BroadcastChannel is closed`).

## How

- Add a guarded `WorkerRegistry.resetForTesting()` (throws outside `test`/`development`, mirroring the existing guard on `cluster.js`'s `scanListeners`) that closes `ANNOUNCEMENT_CHANNEL`, the per-thread channel, and every registered worker's channel, then resets `workers`/`requests`/`historicMetrics`/`listenersAdded`.
- Call it everywhere a test loads a fresh module instance via `jest.resetModules()`, including a 30-iteration loop that previously leaked 30 channels per run and closed none.
- Replace the `discovery`/echo pattern in the two affected tests with polling the already-existing `WorkerRegistry.workerCount()` — a real signal, rather than hoping to observe an echo that a self-posted `BroadcastChannel` message never actually delivers back to its own sender.

## Test plan

- [x] `npx jest` — full suite passes (581/581 on current `main`)
- [x] `npx eslint . && npx prettier . --check && npx tsc --project .` — all clean
- [x] Previously-flaky tests pass in the full file run (30/30 across repeated runs)
- [x] Previously-flaky tests pass in true isolation too (`-t "..."`, 5/5 each) — this is the actual proof the fragility is gone, not just hidden
- [x] The "Jest did not exit... asynchronous operations" open-handle warning that showed up intermittently before this fix no longer appears

Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)