### PR TITLE
Alphabetize default metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this
 project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Breaking
+
+### Changed
+
+- Organized default metrics
+
+### Added
+
 ## [0.16.0] - 2026-08-24
 
 This release marks our first release as a Prometheus subproject.

--- a/lib/defaultMetrics.js
+++ b/lib/defaultMetrics.js
@@ -32,26 +32,28 @@ const heapSpacesSizeAndUsed = require('./metrics/heapSpacesSizeAndUsed');
 const version = require('./metrics/version');
 const gc = require('./metrics/gc');
 
+// Ordered alphabetically by the default Prometheus metric name(s) each
+// module registers, so metrics are reported in a stable, predictable order.
 const metrics = {
-	processCpuTotal,
-	processStartTime,
-	osMemoryHeap,
-	processOpenFileDescriptors,
-	processMaxFileDescriptors,
-	eventLoopLag,
-	eventLoopUtilization,
+	processHandles,
+	processRequests,
 
 	...(typeof process !== 'undefined' &&
 	// eslint-disable-next-line n/no-unsupported-features/node-builtins
 	typeof process.getActiveResourcesInfo === 'function'
 		? { processResources }
 		: {}),
-	processHandles,
-	processRequests,
+	eventLoopLag,
+	eventLoopUtilization,
 	heapSizeAndUsed,
+	gc,
 	heapSpacesSizeAndUsed,
 	version,
-	gc,
+	processCpuTotal,
+	processMaxFileDescriptors,
+	processOpenFileDescriptors,
+	osMemoryHeap,
+	processStartTime,
 };
 const metricsList = Object.keys(metrics);
 

--- a/lib/defaultMetrics.js
+++ b/lib/defaultMetrics.js
@@ -32,9 +32,13 @@ const heapSpacesSizeAndUsed = require('./metrics/heapSpacesSizeAndUsed');
 const version = require('./metrics/version');
 const gc = require('./metrics/gc');
 
-// Ordered alphabetically by the default Prometheus metric name(s) each
-// module registers, so metrics are reported in a stable, predictable order.
+// `version` is deliberately first: it reports build and deployment
+// configuration rather than a runtime statistic, and is easier to spot at the
+// top of the output. Every other module is ordered alphabetically by the
+// default Prometheus metric name(s) it registers, so metrics are reported in a
+// stable, predictable order.
 const metrics = {
+	version,
 	processHandles,
 	processRequests,
 
@@ -48,7 +52,6 @@ const metrics = {
 	heapSizeAndUsed,
 	gc,
 	heapSpacesSizeAndUsed,
-	version,
 	processCpuTotal,
 	processMaxFileDescriptors,
 	processOpenFileDescriptors,

--- a/lib/metrics/heapSizeAndUsed.js
+++ b/lib/metrics/heapSizeAndUsed.js
@@ -17,9 +17,9 @@
 const Gauge = require('../gauge');
 const safeMemoryUsage = require('./helpers/safeMemoryUsage');
 
+const NODEJS_EXTERNAL_MEMORY = 'nodejs_external_memory_bytes';
 const NODEJS_HEAP_SIZE_TOTAL = 'nodejs_heap_size_total_bytes';
 const NODEJS_HEAP_SIZE_USED = 'nodejs_heap_size_used_bytes';
-const NODEJS_EXTERNAL_MEMORY = 'nodejs_external_memory_bytes';
 
 module.exports = (registry, config = {}) => {
 	if (typeof process.memoryUsage !== 'function') {
@@ -33,21 +33,27 @@ module.exports = (registry, config = {}) => {
 	const collect = () => {
 		const memUsage = safeMemoryUsage();
 		if (memUsage) {
-			heapSizeTotal.set(labels, memUsage.heapTotal);
-			heapSizeUsed.set(labels, memUsage.heapUsed);
 			if (memUsage.external !== undefined) {
 				externalMemUsed.set(labels, memUsage.external);
 			}
+			heapSizeTotal.set(labels, memUsage.heapTotal);
+			heapSizeUsed.set(labels, memUsage.heapUsed);
 		}
 	};
 
+	const externalMemUsed = new Gauge({
+		name: namePrefix + NODEJS_EXTERNAL_MEMORY,
+		help: 'Node.js external memory size in bytes.',
+		registers,
+		labelNames,
+		// Use this one metric's `collect` to set all metrics' values.
+		collect,
+	});
 	const heapSizeTotal = new Gauge({
 		name: namePrefix + NODEJS_HEAP_SIZE_TOTAL,
 		help: 'Process heap size from Node.js in bytes.',
 		registers,
 		labelNames,
-		// Use this one metric's `collect` to set all metrics' values.
-		collect,
 	});
 	const heapSizeUsed = new Gauge({
 		name: namePrefix + NODEJS_HEAP_SIZE_USED,
@@ -55,16 +61,10 @@ module.exports = (registry, config = {}) => {
 		registers,
 		labelNames,
 	});
-	const externalMemUsed = new Gauge({
-		name: namePrefix + NODEJS_EXTERNAL_MEMORY,
-		help: 'Node.js external memory size in bytes.',
-		registers,
-		labelNames,
-	});
 };
 
 module.exports.metricNames = [
+	NODEJS_EXTERNAL_MEMORY,
 	NODEJS_HEAP_SIZE_TOTAL,
 	NODEJS_HEAP_SIZE_USED,
-	NODEJS_EXTERNAL_MEMORY,
 ];

--- a/test/defaultMetricsTest.js
+++ b/test/defaultMetricsTest.js
@@ -115,6 +115,14 @@ describe.each([
 		});
 	});
 
+	it('should register default metric modules in alphabetical order of their metric names', () => {
+		const moduleKeys = collectDefaultMetrics.metricsList;
+		const firstNames = moduleKeys.map(
+			key => require(`../lib/metrics/${key}`).metricNames[0],
+		);
+		expect(firstNames).toEqual([...firstNames].sort());
+	});
+
 	describe('custom registry', () => {
 		it('should allow to register metrics to custom registry', async () => {
 			const registry = new Registry(regType);

--- a/test/defaultMetricsTest.js
+++ b/test/defaultMetricsTest.js
@@ -115,11 +115,13 @@ describe.each([
 		});
 	});
 
-	it('should register default metric modules in alphabetical order of their metric names', () => {
+	it('should register version first, then the remaining default metric modules in alphabetical order of their metric names', () => {
 		const moduleKeys = collectDefaultMetrics.metricsList;
-		const firstNames = moduleKeys.map(
-			key => require(`../lib/metrics/${key}`).metricNames[0],
-		);
+		expect(moduleKeys[0]).toBe('version');
+
+		const firstNames = moduleKeys
+			.slice(1)
+			.map(key => require(`../lib/metrics/${key}`).metricNames[0]);
 		expect(firstNames).toEqual([...firstNames].sort());
 	});
 

--- a/test/metrics/heapSizeAndUsedTest.js
+++ b/test/metrics/heapSizeAndUsedTest.js
@@ -39,8 +39,13 @@ describe.each([
 		};
 
 		heapSizeAndUsed();
-		// Note: these three gauges' values are set by the _total gauge's
-		// "collect" function.
+		// Note: these three gauges' values are set by the external memory
+		// gauge's "collect" function, so it must be read first.
+
+		const externalGauge = globalRegistry.getSingleMetric(
+			'nodejs_external_memory_bytes',
+		);
+		expect((await externalGauge.get()).values[0].value).toEqual(100);
 
 		const totalGauge = globalRegistry.getSingleMetric(
 			'nodejs_heap_size_total_bytes',
@@ -51,10 +56,5 @@ describe.each([
 			'nodejs_heap_size_used_bytes',
 		);
 		expect((await usedGauge.get()).values[0].value).toEqual(500);
-
-		const externalGauge = globalRegistry.getSingleMetric(
-			'nodejs_external_memory_bytes',
-		);
-		expect((await externalGauge.get()).values[0].value).toEqual(100);
 	});
 });


### PR DESCRIPTION
Closes #810.

- Reorder the `metrics` object in `lib/defaultMetrics.js` alphabetically by each module's Prometheus metric name.
- In `heapSizeAndUsed.js`, move the shared `collect()` from the `total` gauge to the `external` gauge, since `nodejs_external_memory_bytes` now registers first alphabetically.
- Add a test verifying default metric modules register in alphabetical order.
- Update the existing heapSizeAndUsed test to read the `external` gauge first, since it now owns the shared collect.