### PR TITLE
fix(registry): default to summation for metrics without an aggregator

### DIFF
--- a/lib/registry.js
+++ b/lib/registry.js
@@ -53,7 +53,8 @@ class Registry {
 			return Array.from(values);
 		} else {
 			return Array.from(
-				values.filter(metric => aggregator === metric.aggregator),
+				// metrics without an explicit aggregator default to 'sum'
+				values.filter(metric => aggregator === (metric.aggregator ?? 'sum')),
 			);
 		}
 	}
@@ -279,7 +280,10 @@ class Registry {
 
 		// Aggregate gathered metrics.
 		metricsByName.forEach(metrics => {
-			const aggregatorName = metrics[0].aggregator;
+			// Metrics without an explicit aggregator are summed (see the
+			// `aggregator` config docs and the worker/cluster shutdown path,
+			// which relies on that default).
+			const aggregatorName = metrics[0].aggregator ?? 'sum';
 			const aggregatorFn = aggregators[aggregatorName];
 			if (typeof aggregatorFn !== 'function') {
 				throw new Error(`'${aggregatorName}' is not a defined aggregator.`);

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -1034,6 +1034,33 @@ describe('Register', () => {
 					aggregator: 'first',
 				});
 			});
+
+			it('defaults to summation for snapshots without an aggregator property', () => {
+				const noAggregator = [
+					{
+						help: 'A custom metric registered via registerMetric()',
+						name: 'custom_metric_without_aggregator',
+						type: 'gauge',
+						values: [{ value: 5, labels: {} }],
+					},
+				];
+
+				const reg = Registry.aggregate([noAggregator, noAggregator], regType);
+				const metric = reg
+					.getSingleMetric('custom_metric_without_aggregator')
+					.get();
+				expect(metric.values[0].value).toEqual(10);
+			});
+
+			it('includes metrics without an aggregator when filtering by "sum"', async () => {
+				const register = new Registry();
+				register.registerMetric(getMetric());
+
+				expect(register.getMetricsAsArray('sum').length).toEqual(1);
+				const output = await register.getMetricsAsJSON('sum');
+				expect(output.length).toEqual(1);
+				expect(output[0].name).toEqual('test_metric');
+			});
 		});
 
 		function getMetric(name) {


### PR DESCRIPTION
## Problem

Both the README ("Custom metrics are summed across workers by default") and the worker/cluster JSDoc ("or by summation if `aggregator` is undefined") promise a `'sum'` fallback for metrics without an explicit `aggregator`. Two recent changes broke that contract:

1. `Registry.aggregate()` throws `'undefined' is not a defined aggregator.` when any snapshot lacks the property — snapshots produced by `registerMetric()` with a plain object, or hand-written wrappers. This crashes `clusterMetrics()` / `workerMetrics()` entirely.
2. `getMetricsAsArray('sum')` silently filters those metrics out (`aggregator === metric.aggregator` is false when the property is missing), so their values are lost on the shutdown-flush path added for workers in ef1cea2.

Reproduction on current main:

```js
const { Registry } = require('prom-client');
Registry.aggregate([
  [{ help: 'h', name: 'm', type: 'gauge', values: [{ value: 5, labels: {} }] }],
]);
// Error: 'undefined' is not a defined aggregator.
```

and:

```js
const register = new Registry();
new Counter({ name: 'normal', help: 'h', registers: [register] }); // aggregator defaults to 'sum'
register.getMetricsAsArray('sum').length; // 0 if the metric object lacks .aggregator
```

Note that `new Counter({...})` sets `aggregator: 'sum'` via the Metric constructor default, so built-in metric classes mask the issue; it only surfaces with wrapper/plain-object metrics, which is exactly what the aggregation and shutdown paths produce internally.

## Fix

Restore the documented `'sum'` fallback in both places (`metric.aggregator ?? 'sum'`).

## Testing

- two new tests in `test/registerTest.js`: aggregate() sums snapshots without an aggregator; getMetricsAsArray('sum') / getMetricsAsJSON('sum') include them
- full unit suite: 29 suites / 581 tests passing