### PR TITLE
test: cover Metric constructor validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ dependencies and any `require()`/`import` statements accordingly.
 
 ### Changed
 
+- Add direct test coverage for the base metric constructor contract
 - Allow `Pushgateway` to accept a custom registry as the second constructor argument
 - Add `Registry#getMetricsAsString()` to the TypeScript definitions
 - Improve types for no labels

--- a/test/metricTest.js
+++ b/test/metricTest.js
@@ -1,0 +1,75 @@
+// Copyright The Prometheus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+'use strict';
+
+const { Metric } = require('../lib/metric');
+
+class TestMetric extends Metric {
+	reset() {
+		this.resetCalls = (this.resetCalls ?? 0) + 1;
+	}
+}
+
+describe('Metric', () => {
+	it('requires a configuration object', () => {
+		expect(() => new TestMetric(null)).toThrow(
+			new TypeError('constructor expected a config object'),
+		);
+	});
+
+	it('requires help text', () => {
+		expect(
+			() => new TestMetric({ name: 'test_metric', registers: [] }),
+		).toThrow(new Error('Missing mandatory help parameter'));
+	});
+
+	it('requires a name', () => {
+		expect(
+			() => new TestMetric({ help: 'Test metric', registers: [] }),
+		).toThrow(new Error('Missing mandatory name parameter'));
+	});
+
+	it('rejects a non-function collect option', () => {
+		expect(
+			() =>
+				new TestMetric({
+					name: 'test_metric',
+					help: 'Test metric',
+					collect: true,
+					registers: [],
+				}),
+		).toThrow(new Error('Optional "collect" parameter must be a function'));
+	});
+
+	it('applies defaults, sorts labels, and resets on construction', () => {
+		const collect = jest.fn();
+		const metric = new TestMetric({
+			name: 'test_metric',
+			help: 'Test metric',
+			labelNames: ['status', 'method'],
+			collect,
+			registers: [],
+		});
+
+		expect(metric).toMatchObject({
+			aggregator: 'sum',
+			collect,
+			enableExemplars: false,
+			labelNames: ['status', 'method'],
+			resetCalls: 1,
+			sortedLabelNames: ['method', 'status'],
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- add direct tests for the shared `Metric` constructor validation contract
- verify the valid path applies defaults, sorts labels, and calls `reset()`
- include the required changelog entry

This is test-only and does not change runtime behavior.

Refs #805 (focused coverage improvement; intentionally does not close the broader issue)

## Coverage

For `lib/metric.js` in the full suite:

- statements/lines: 82.14% → 96.42%
- branches: 78.26% → 95.65%

## Testing

- `npm test` — lint, Prettier, TypeScript, 30 suites and 588 tests pass
- focused test on Node.js 22 — 5 tests pass
- focused test on Node.js 24 — 5 tests pass
- full suite and coverage on Node.js 26 — 588 tests pass