### PR TITLE
perf: remove truthy checks from default metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - Organized default metrics
 - perf: Histogram rendering builds its export list straight from the store iterator instead of an intermediate array. Faster at high series counts on Node 24 and 26, can be slightly slower on Node 22
 - fix: Correct content type exported for cluster and worker mode.
+- perf: Remove truthy conditionals from default metric collectors
 
 ### Added
 

--- a/lib/metrics/eventLoopLag.js
+++ b/lib/metrics/eventLoopLag.js
@@ -48,17 +48,20 @@ function reportEventloopLag(start, gauge, labels) {
 }
 
 module.exports = (registry, config = {}) => {
-	const namePrefix = config.prefix ? config.prefix : '';
-	const labels = config.labels ? config.labels : {};
+	const namePrefix = config.prefix ?? '';
+	const labels = config.labels ?? {};
 	const labelNames = Object.keys(labels);
-	const registers = registry ? [registry] : undefined;
+	const registers = registry === undefined ? undefined : [registry];
 
 	let collect = () => {
 		const start = process.hrtime();
 		setImmediate(reportEventloopLag, start, lag, labels);
 	};
 
-	if (perf_hooks && perf_hooks.monitorEventLoopDelay) {
+	if (
+		perf_hooks !== undefined &&
+		typeof perf_hooks.monitorEventLoopDelay === 'function'
+	) {
 		try {
 			const histogram = perf_hooks.monitorEventLoopDelay({
 				resolution: config.eventLoopMonitoringPrecision,

--- a/lib/metrics/eventLoopUtilization.js
+++ b/lib/metrics/eventLoopUtilization.js
@@ -26,7 +26,7 @@ module.exports = (registry, config = {}) => {
 	const namePrefix = config.prefix ?? '';
 	const labels = config.labels ?? {};
 	const labelNames = Object.keys(labels);
-	const registers = registry ? [registry] : undefined;
+	const registers = registry === undefined ? undefined : [registry];
 
 	const ageBuckets = config.eventLoopUtilizationAgeBuckets ?? 5;
 

--- a/lib/metrics/gc.js
+++ b/lib/metrics/gc.js
@@ -31,7 +31,7 @@ const DEFAULT_GC_DURATION_BUCKETS = [0.001, 0.01, 0.1, 1, 2, 5];
 
 const kinds = [];
 
-if (perf_hooks && perf_hooks.constants) {
+if (perf_hooks !== undefined && perf_hooks.constants !== undefined) {
 	kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_MAJOR] = 'major';
 	kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_MINOR] = 'minor';
 	kinds[perf_hooks.constants.NODE_PERFORMANCE_GC_INCREMENTAL] = 'incremental';
@@ -39,23 +39,21 @@ if (perf_hooks && perf_hooks.constants) {
 }
 
 module.exports = (registry, config = {}) => {
-	if (!perf_hooks) {
+	if (perf_hooks === undefined) {
 		return;
 	}
 
-	const namePrefix = config.prefix ? config.prefix : '';
-	const labels = config.labels ? config.labels : {};
+	const namePrefix = config.prefix ?? '';
+	const labels = config.labels ?? {};
 	const labelNames = Object.keys(labels);
-	const buckets = config.gcDurationBuckets
-		? config.gcDurationBuckets
-		: DEFAULT_GC_DURATION_BUCKETS;
+	const buckets = config.gcDurationBuckets ?? DEFAULT_GC_DURATION_BUCKETS;
 	const gcHistogram = new Histogram({
 		name: namePrefix + NODEJS_GC_DURATION_SECONDS,
 		help: 'Garbage collection duration by kind, one of major, minor, incremental or weakcb.',
 		labelNames: ['kind', ...labelNames],
 		enableExemplars: false,
 		buckets,
-		registers: registry ? [registry] : undefined,
+		registers: registry === undefined ? undefined : [registry],
 	});
 
 	const obs = new perf_hooks.PerformanceObserver(list => {
@@ -63,7 +61,7 @@ module.exports = (registry, config = {}) => {
 		// Node < 16 uses entry.kind
 		// Node >= 16 uses entry.detail.kind
 		// See: https://nodejs.org/docs/latest-v16.x/api/deprecations.html#deprecations_dep0152_extension_performanceentry_properties
-		const kind = entry.detail ? kinds[entry.detail.kind] : kinds[entry.kind];
+		const kind = kinds[(entry.detail ?? entry).kind];
 		// Convert duration from milliseconds to seconds
 		gcHistogram.observe(Object.assign({ kind }, labels), entry.duration / 1000);
 	});

--- a/lib/metrics/heapSizeAndUsed.js
+++ b/lib/metrics/heapSizeAndUsed.js
@@ -25,14 +25,14 @@ module.exports = (registry, config = {}) => {
 	if (typeof process.memoryUsage !== 'function') {
 		return;
 	}
-	const labels = config.labels ? config.labels : {};
+	const labels = config.labels ?? {};
 	const labelNames = Object.keys(labels);
 
-	const registers = registry ? [registry] : undefined;
-	const namePrefix = config.prefix ? config.prefix : '';
+	const registers = registry === undefined ? undefined : [registry];
+	const namePrefix = config.prefix ?? '';
 	const collect = () => {
 		const memUsage = safeMemoryUsage();
-		if (memUsage) {
+		if (memUsage !== undefined) {
 			if (memUsage.external !== undefined) {
 				externalMemUsed.set(labels, memUsage.external);
 			}

--- a/lib/metrics/heapSpacesSizeAndUsed.js
+++ b/lib/metrics/heapSpacesSizeAndUsed.js
@@ -33,10 +33,10 @@ module.exports = (registry, config = {}) => {
 		}
 		throw e;
 	}
-	const registers = registry ? [registry] : undefined;
-	const namePrefix = config.prefix ? config.prefix : '';
+	const registers = registry === undefined ? undefined : [registry];
+	const namePrefix = config.prefix ?? '';
 
-	const labels = config.labels ? config.labels : {};
+	const labels = config.labels ?? {};
 	const labelNames = ['space', ...Object.keys(labels)];
 
 	const gauges = {};

--- a/lib/metrics/osMemoryHeap.js
+++ b/lib/metrics/osMemoryHeap.js
@@ -21,14 +21,14 @@ const safeRss = require('./helpers/safeRss');
 const PROCESS_RESIDENT_MEMORY = 'process_resident_memory_bytes';
 
 function notLinuxVariant(registry, config = {}) {
-	const namePrefix = config.prefix ? config.prefix : '';
-	const labels = config.labels ? config.labels : {};
+	const namePrefix = config.prefix ?? '';
+	const labels = config.labels ?? {};
 	const labelNames = Object.keys(labels);
 
 	new Gauge({
 		name: namePrefix + PROCESS_RESIDENT_MEMORY,
 		help: 'Resident memory size in bytes.',
-		registers: registry ? [registry] : undefined,
+		registers: registry === undefined ? undefined : [registry],
 		labelNames,
 		collect() {
 			// process.memoryUsage.rss() is faster than process.memoryUsage() as it

--- a/lib/metrics/osMemoryHeapLinux.js
+++ b/lib/metrics/osMemoryHeapLinux.js
@@ -48,9 +48,9 @@ function structureOutput(input) {
 }
 
 module.exports = (registry, config = {}) => {
-	const registers = registry ? [registry] : undefined;
-	const namePrefix = config.prefix ? config.prefix : '';
-	const labels = config.labels ? config.labels : {};
+	const registers = registry === undefined ? undefined : [registry];
+	const namePrefix = config.prefix ?? '';
+	const labels = config.labels ?? {};
 	const labelNames = Object.keys(labels);
 
 	const residentMemGauge = new Gauge({

--- a/lib/metrics/processCpuTotal.js
+++ b/lib/metrics/processCpuTotal.js
@@ -22,10 +22,10 @@ const PROCESS_CPU_SYSTEM_SECONDS = 'process_cpu_system_seconds_total';
 const PROCESS_CPU_SECONDS = 'process_cpu_seconds_total';
 
 module.exports = (registry, config = {}) => {
-	const registers = registry ? [registry] : undefined;
-	const namePrefix = config.prefix ? config.prefix : '';
-	const labels = config.labels ? config.labels : {};
-	const exemplars = config.enableExemplars ? config.enableExemplars : false;
+	const registers = registry === undefined ? undefined : [registry];
+	const namePrefix = config.prefix ?? '';
+	const labels = config.labels ?? {};
+	const exemplars = config.enableExemplars ?? false;
 	const labelNames = Object.keys(labels);
 
 	let lastCpuUsage = process.cpuUsage();
@@ -48,7 +48,7 @@ module.exports = (registry, config = {}) => {
 			if (this.enableExemplars) {
 				let exemplarLabels = {};
 				const currentSpan = OtelApi.trace.getSpan(OtelApi.context.active());
-				if (currentSpan) {
+				if (currentSpan !== undefined) {
 					exemplarLabels = {
 						traceId: currentSpan.spanContext().traceId,
 						spanId: currentSpan.spanContext().spanId,

--- a/lib/metrics/processHandles.js
+++ b/lib/metrics/processHandles.js
@@ -27,9 +27,9 @@ module.exports = (registry, config = {}) => {
 		return;
 	}
 
-	const registers = registry ? [registry] : undefined;
-	const namePrefix = config.prefix ? config.prefix : '';
-	const labels = config.labels ? config.labels : {};
+	const registers = registry === undefined ? undefined : [registry];
+	const namePrefix = config.prefix ?? '';
+	const labels = config.labels ?? {};
 	const labelNames = Object.keys(labels);
 
 	new Gauge({

--- a/lib/metrics/processMaxFileDescriptors.js
+++ b/lib/metrics/processMaxFileDescriptors.js
@@ -45,14 +45,14 @@ module.exports = (registry, config = {}) => {
 
 	if (maxFds === undefined) return;
 
-	const namePrefix = config.prefix ? config.prefix : '';
-	const labels = config.labels ? config.labels : {};
+	const namePrefix = config.prefix ?? '';
+	const labels = config.labels ?? {};
 	const labelNames = Object.keys(labels);
 
 	new Gauge({
 		name: namePrefix + PROCESS_MAX_FDS,
 		help: 'Maximum number of open file descriptors.',
-		registers: registry ? [registry] : undefined,
+		registers: registry === undefined ? undefined : [registry],
 		labelNames,
 		collect() {
 			if (maxFds !== undefined) this.set(labels, maxFds);

--- a/lib/metrics/processOpenFileDescriptors.js
+++ b/lib/metrics/processOpenFileDescriptors.js
@@ -28,14 +28,14 @@ module.exports = (registry, config = {}) => {
 		return;
 	}
 
-	const namePrefix = config.prefix ? config.prefix : '';
-	const labels = config.labels ? config.labels : {};
+	const namePrefix = config.prefix ?? '';
+	const labels = config.labels ?? {};
 	const labelNames = Object.keys(labels);
 
 	new Gauge({
 		name: namePrefix + PROCESS_OPEN_FDS,
 		help: 'Number of open file descriptors.',
-		registers: registry ? [registry] : undefined,
+		registers: registry === undefined ? undefined : [registry],
 		labelNames,
 		collect() {
 			try {

--- a/lib/metrics/processRequests.js
+++ b/lib/metrics/processRequests.js
@@ -26,15 +26,15 @@ module.exports = (registry, config = {}) => {
 		return;
 	}
 
-	const namePrefix = config.prefix ? config.prefix : '';
-	const labels = config.labels ? config.labels : {};
+	const namePrefix = config.prefix ?? '';
+	const labels = config.labels ?? {};
 	const labelNames = Object.keys(labels);
 
 	new Gauge({
 		name: namePrefix + NODEJS_ACTIVE_REQUESTS,
 		help: 'Number of active libuv requests grouped by request type. Every request type is C++ class name.',
 		labelNames: ['type', ...labelNames],
-		registers: registry ? [registry] : undefined,
+		registers: registry === undefined ? undefined : [registry],
 		collect() {
 			const requests = process._getActiveRequests();
 			updateMetrics(this, aggregateByObjectName(requests), labels);
@@ -44,7 +44,7 @@ module.exports = (registry, config = {}) => {
 	new Gauge({
 		name: namePrefix + NODEJS_ACTIVE_REQUESTS_TOTAL,
 		help: 'Total number of active requests.',
-		registers: registry ? [registry] : undefined,
+		registers: registry === undefined ? undefined : [registry],
 		labelNames,
 		collect() {
 			const requests = process._getActiveRequests();

--- a/lib/metrics/processResources.js
+++ b/lib/metrics/processResources.js
@@ -26,15 +26,15 @@ module.exports = (registry, config = {}) => {
 		return;
 	}
 
-	const namePrefix = config.prefix ? config.prefix : '';
-	const labels = config.labels ? config.labels : {};
+	const namePrefix = config.prefix ?? '';
+	const labels = config.labels ?? {};
 	const labelNames = Object.keys(labels);
 
 	new Gauge({
 		name: namePrefix + NODEJS_ACTIVE_RESOURCES,
 		help: 'Number of active resources that are currently keeping the event loop alive, grouped by async resource type.',
 		labelNames: ['type', ...labelNames],
-		registers: registry ? [registry] : undefined,
+		registers: registry === undefined ? undefined : [registry],
 		collect() {
 			// eslint-disable-next-line n/no-unsupported-features/node-builtins
 			const resources = process.getActiveResourcesInfo();
@@ -58,7 +58,7 @@ module.exports = (registry, config = {}) => {
 	new Gauge({
 		name: namePrefix + NODEJS_ACTIVE_RESOURCES_TOTAL,
 		help: 'Total number of active resources.',
-		registers: registry ? [registry] : undefined,
+		registers: registry === undefined ? undefined : [registry],
 		labelNames,
 		collect() {
 			// eslint-disable-next-line n/no-unsupported-features/node-builtins

--- a/lib/metrics/processStartTime.js
+++ b/lib/metrics/processStartTime.js
@@ -26,14 +26,14 @@ const startInSeconds = Math.round(Date.now() / 1000 - uptime);
 const PROCESS_START_TIME = 'process_start_time_seconds';
 
 module.exports = (registry, config = {}) => {
-	const namePrefix = config.prefix ? config.prefix : '';
-	const labels = config.labels ? config.labels : {};
+	const namePrefix = config.prefix ?? '';
+	const labels = config.labels ?? {};
 	const labelNames = Object.keys(labels);
 
 	new Gauge({
 		name: namePrefix + PROCESS_START_TIME,
 		help: 'Start time of the process since unix epoch in seconds.',
-		registers: registry ? [registry] : undefined,
+		registers: registry === undefined ? undefined : [registry],
 		labelNames,
 		aggregator: 'omit',
 		collect() {

--- a/lib/metrics/version.js
+++ b/lib/metrics/version.js
@@ -26,15 +26,15 @@ const versionSegments = version.slice(1).split('.').map(Number);
 const NODE_VERSION_INFO = 'nodejs_version_info';
 
 module.exports = (registry, config = {}) => {
-	const namePrefix = config.prefix ? config.prefix : '';
-	const labels = config.labels ? config.labels : {};
+	const namePrefix = config.prefix ?? '';
+	const labels = config.labels ?? {};
 	const labelNames = Object.keys(labels);
 
 	new Gauge({
 		name: namePrefix + NODE_VERSION_INFO,
 		help: 'Node.js version info.',
 		labelNames: ['version', 'major', 'minor', 'patch', ...labelNames],
-		registers: registry ? [registry] : undefined,
+		registers: registry === undefined ? undefined : [registry],
 		aggregator: 'first',
 		collect() {
 			// Needs to be in collect() so value is present even if reg is reset


### PR DESCRIPTION
Closes #823.

This removes the remaining truthy defaults and optional-object checks from the default metric collectors. Configuration defaults now use nullish coalescing, while optional registries, `perf_hooks`, memory usage results, and active spans use explicit `undefined` checks.

The change is limited to `lib/metrics` so it does not overlap the core metric, histogram, registry utility, or worker files currently touched by open pull requests. Supported input behavior is unchanged, and the changelog records the performance cleanup.

Verification:

- `npm test`
  - ESLint
  - Prettier check
  - TypeScript compilation
  - 590 Jest tests with coverage
