### PR TITLE
Resurrect Benjamin's fix: Add missing properties to metrics from abstract class Metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Additional TS typedefs for Metrics
+
 ## [0.16.0] - 2026-08-24
 
 This release marks our first release as a Prometheus subproject.

--- a/index.d.ts
+++ b/index.d.ts
@@ -300,6 +300,38 @@ export type Metric<T extends string = NoLabelNameType> =
 	| Summary<T>
 	| Histogram<T>;
 
+declare abstract class AbstractMetric {
+	/**
+	 * The name of the metric.
+	 */
+	readonly name: string;
+
+	/**
+	 * The help text of the metric.
+	 */
+	readonly help: string;
+
+	/**
+	 * List of registers attached to the metric.
+	 */
+	readonly registers: readonly Registry[];
+
+	/**
+	 * List of label names attached to the metric.
+	 */
+	readonly labelNames: readonly string[];
+
+	/**
+	 * The aggregation method used for aggregating this metric in a Node.js cluster.
+	 */
+	readonly aggregator: Aggregator;
+
+	/**
+	 * If provided, the collect function of the metric, which is invoked on each scrape.
+	 */
+	readonly collect?: CollectFunction<this>;
+}
+
 /**
  * Aggregation methods, used for aggregating metrics in a Node.js cluster.
  */
@@ -374,7 +406,9 @@ export interface ObserveDataWithExemplar<T extends string> {
 /**
  * A counter is a cumulative metric that represents a single numerical value that only ever goes up
  */
-export class Counter<T extends string = NoLabelNameType> {
+export class Counter<
+	T extends string = NoLabelNameType,
+> extends AbstractMetric {
 	/**
 	 * @param configuration Configuration when creating a Counter metric. Name and Help is required.
 	 */
@@ -455,7 +489,7 @@ export interface GaugeConfiguration<
 /**
  * A gauge is a metric that represents a single numerical value that can arbitrarily go up and down.
  */
-export class Gauge<T extends string = NoLabelNameType> {
+export class Gauge<T extends string = NoLabelNameType> extends AbstractMetric {
 	/**
 	 * @param configuration Configuration when creating a Gauge metric. Name and Help is mandatory
 	 */
@@ -597,7 +631,9 @@ export interface HistogramConfiguration<
 /**
  * A histogram samples observations (usually things like request durations or response sizes) and counts them in configurable buckets
  */
-export class Histogram<T extends string = NoLabelNameType> {
+export class Histogram<
+	T extends string = NoLabelNameType,
+> extends AbstractMetric {
 	/**
 	 * @param configuration Configuration when creating the Histogram. Name and Help is mandatory
 	 */
@@ -724,7 +760,9 @@ export interface SummaryConfiguration<
 /**
  * A summary samples observations
  */
-export class Summary<T extends string = NoLabelNameType> {
+export class Summary<
+	T extends string = NoLabelNameType,
+> extends AbstractMetric {
 	/**
 	 * @param configuration Configuration when creating Summary metric. Name and Help is mandatory
 	 */


### PR DESCRIPTION
Very old PRs glitch on Github Actions and the only way I know how to fix them from third parties who are no longer active, is to rely on DVCS to let me resubmit them on their behalf. 

Reintroduces #647 