### PR TITLE
Fix incorrect scraping with contentType === OpenMetrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Organized default metrics
 - perf: Histogram rendering builds its export list straight from the store iterator instead of an intermediate array. Faster at high series counts on Node 24 and 26, can be slightly slower on Node 22
+- fix: Correct content type exported for cluster and worker mode.
 
 ### Added
 

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -133,7 +133,10 @@ class AggregatorRegistry extends Registry {
 	async #gather(requestId, historical, promises) {
 		const responses = await Promise.all(promises);
 		const metrics = responses.flatMap(response => response.metrics);
-		return Registry.aggregate([historical, ...metrics]).metrics();
+		return Registry.aggregate(
+			[historical, ...metrics],
+			this.contentType,
+		).metrics();
 	}
 
 	get contentType() {

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -141,7 +141,10 @@ class WorkerRegistry extends Registry {
 		const responses = await Promise.all(promises);
 		debug('Aggregating data...', requestId);
 		const metrics = responses.flatMap(response => response.metrics);
-		return Registry.aggregate([historical, ...metrics]).metrics();
+		return Registry.aggregate(
+			[historical, ...metrics],
+			this.contentType,
+		).metrics();
 	}
 
 	get contentType() {

--- a/test/clusterTest.js
+++ b/test/clusterTest.js
@@ -97,7 +97,23 @@ describe.each([
 		it('works properly if there are no cluster workers', async () => {
 			const ar = new AggregatorRegistry(regType);
 			const metrics = await ar.clusterMetrics();
-			expect(metrics.trim()).toEqual('');
+
+			if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
+				expect(metrics).toContain('# EOF\n');
+			} else {
+				expect(metrics.trim()).toEqual('');
+			}
+		});
+
+		it('formats in the correct content type', async () => {
+			const ar = new AggregatorRegistry(regType);
+			const metrics = await ar.clusterMetrics();
+
+			if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
+				expect(metrics).toContain('# EOF\n');
+			} else {
+				expect(metrics.trim()).toEqual('');
+			}
 		});
 
 		it("listeners don't accumulate", () => {

--- a/test/workerTest.js
+++ b/test/workerTest.js
@@ -34,6 +34,16 @@ function metric(value) {
 	};
 }
 
+function counter(value) {
+	return {
+		help: 'test metric two',
+		name: 'test_metric_two_counter',
+		type: 'counter',
+		values: [{ labels: {}, value }],
+		aggregator: 'sum',
+	};
+}
+
 describe.each([
 	['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
 	['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
@@ -43,29 +53,74 @@ describe.each([
 	});
 
 	describe('WorkerRegistry.workerMetrics()', () => {
-		it('works properly if there are no workers', async () => {
-			const WorkerRegistry = require('../lib/worker');
-			const registry = new WorkerRegistry(regType);
-			const metrics = await registry.workerMetrics();
-			expect(metrics).toEqual('');
-		});
+		let AggregatorRegistry;
+		let announcementChannel;
+		let registry;
+		let discovery;
 
-		it('aggregates worker responses in thread id order', async () => {
+		beforeEach(async () => {
 			jest.resetModules();
-			const AggregatorRegistry = require('../lib/worker');
-			const registry = new AggregatorRegistry(regType);
-			const announcementChannel = new BroadcastChannel(
+			AggregatorRegistry = require('../lib/worker');
+			registry = new AggregatorRegistry(regType);
+			announcementChannel = new BroadcastChannel(
 				'@prometheus-io/client:announce',
 			).unref();
 
-			const discovery = new Promise(resolve => {
+			discovery = new Promise(resolve => {
 				announcementChannel.addEventListener('message', async event => {
 					if (event.data.type === ANNOUNCEMENT && !event.data.primary) {
 						resolve(event);
 					}
 				});
 			});
+		});
 
+		afterEach(async () => {
+			announcementChannel.close();
+		});
+
+		it('works properly if there are no workers', async () => {
+			const metrics = await registry.workerMetrics();
+			expect(metrics).toEqual('');
+		});
+
+		it('formats in the correct content type', async () => {
+			const threadId = 211;
+			const name = `@prometheus-io/client:worker:${threadId}`;
+			const channel = new BroadcastChannel(name).unref();
+
+			announcementChannel.postMessage({
+				type: ANNOUNCEMENT,
+				name,
+				threadId,
+			});
+
+			await discovery; // Let announcements arrive
+
+			announcementChannel.addEventListener('message', async event => {
+				if (event.data.type !== GET_METRICS_REQ) return;
+
+				channel.postMessage({
+					type: GET_METRICS_RES,
+					requestId: event.data.requestId,
+					threadId,
+					metrics: [[counter(1.2345)]],
+				});
+			});
+
+			try {
+				const result = await registry.workerMetrics();
+				if (regType === Registry.PROMETHEUS_CONTENT_TYPE) {
+					expect(result).toContain('test_metric_two_counter 1.2345');
+				} else {
+					expect(result).toContain('test_metric_two_counter_total 1.2345');
+				}
+			} finally {
+				channel.close();
+			}
+		});
+
+		it('aggregates worker responses in thread id order', async () => {
 			const responders = [1, 2, 3].map(threadId => {
 				const name = `@prometheus-io/client:worker:${threadId}`;
 				const channel = new BroadcastChannel(name).unref();
@@ -109,7 +164,6 @@ describe.each([
 				await responsesSent;
 				expect(result).toContain('test_metric 1.4765105');
 			} finally {
-				announcementChannel.close();
 				for (const responder of responders) responder.channel.close();
 			}
 		});


### PR DESCRIPTION
The historical data does not need to be modified, mercifully, because it gets modified during any aggregate() call, which should then also cover anyone trying to support both endpoints at once.

Fixes #827 

Note: This should have shipped with 0.16.0 and got lost in the shuffle.  The author who caught this did not get back to me in time. This implementation is compatible with the memory leak changes that were pushed and hopefully with the additional changes that are in PR at the moment.