### PR TITLE
Add option to keep OpenMetrics counter names stable without `_total`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- `Registry.setContentType()` (and the `Registry` constructor) accept a
+  `counterWithoutTotalSuffix: 'unknown'` option. When set, OpenMetrics output
+  keeps the original name and reports type `unknown` for Counters that don't
+  already end in `_total`, instead of the default behavior of renaming them
+  with the suffix appended.
+
 ## [0.16.0] - 2026-08-24
 
 This release marks our first release as a Prometheus subproject.

--- a/README.md
+++ b/README.md
@@ -423,6 +423,25 @@ properties on the `Registry` object.
 The `contentType` constant exposed by the module returns the default content
 type when creating a new registry, currently defaults to Prometheus type.
 
+OpenMetrics requires Counter samples to carry a `_total` suffix, so switching
+a registry to `OPENMETRICS_CONTENT_TYPE` renames any Counter whose name
+doesn't already end in `_total` on the wire (e.g. `foo` becomes `foo_total`).
+If that renaming is undesirable, pass `counterWithoutTotalSuffix: 'unknown'`
+as a second argument to keep the original name and expose the metric with
+type `unknown` instead:
+
+```js
+Prometheus.register.setContentType(
+  Prometheus.Registry.OPENMETRICS_CONTENT_TYPE,
+  {
+    counterWithoutTotalSuffix: 'unknown',
+  },
+);
+```
+
+This only affects Counters that lack a `_total` suffix; the default is
+`'append'`, which preserves the renaming behavior described above.
+
 ### Multiple registries
 
 By default, metrics are automatically registered to the global registry (located

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -26,7 +26,7 @@ class Registry {
 		return 'application/openmetrics-text; version=1.0.0; charset=utf-8';
 	}
 
-	constructor(regContentType = Registry.PROMETHEUS_CONTENT_TYPE) {
+	constructor(regContentType = Registry.PROMETHEUS_CONTENT_TYPE, options = {}) {
 		this._metrics = new Map();
 		this._collectors = [];
 		this._defaultLabels = {};
@@ -37,6 +37,9 @@ class Registry {
 			throw new TypeError(`Content type ${regContentType} is unsupported`);
 		}
 		this._contentType = regContentType;
+		this._counterWithoutTotalSuffix = validateCounterWithoutTotalSuffix(
+			options.counterWithoutTotalSuffix,
+		);
 	}
 
 	/**
@@ -65,9 +68,26 @@ class Registry {
 				? await metrics.getForPromString()
 				: await metrics.get();
 
-		const name = escapeString(metric.name);
+		const isOpenMetrics =
+			this.contentType === Registry.OPENMETRICS_CONTENT_TYPE;
+		const isCounter = metric.type === 'counter';
+		// A counter that isn't already named with a `_total` suffix would
+		// otherwise get silently renamed on the wire when exposed as
+		// OpenMetrics. Demoting it to `unknown` (opt-in via
+		// counterWithoutTotalSuffix: 'unknown') keeps the name stable across
+		// content types instead.
+		const demoteToUnknown =
+			isOpenMetrics &&
+			isCounter &&
+			!metric.name.endsWith('_total') &&
+			this._counterWithoutTotalSuffix === 'unknown';
+		const appendTotalSuffix = isOpenMetrics && isCounter && !demoteToUnknown;
+
+		const name = escapeString(
+			appendTotalSuffix ? standardizeCounterName(metric.name) : metric.name,
+		);
 		const help = `# HELP ${name} ${escapeString(metric.help)}`;
-		const type = `# TYPE ${name} ${metric.type}`;
+		const type = `# TYPE ${name} ${demoteToUnknown ? 'unknown' : metric.type}`;
 		const values = [help, type];
 
 		let defaultLabelNames = Object.keys(this._defaultLabels);
@@ -75,15 +95,9 @@ class Registry {
 			defaultLabelNames = undefined;
 		}
 
-		const isOpenMetrics =
-			this.contentType === Registry.OPENMETRICS_CONTENT_TYPE;
-
 		for (const val of metric.values || []) {
 			const { metricName = name, labels = {}, sharedLabels } = val;
-			const seriesName =
-				isOpenMetrics && metric.type === 'counter'
-					? `${metricName}_total`
-					: metricName;
+			const seriesName = appendTotalSuffix ? `${metricName}_total` : metricName;
 
 			// Make a copy before mutating
 			const seriesLabels =
@@ -127,12 +141,9 @@ class Registry {
 		const isOpenMetrics =
 			this.contentType === Registry.OPENMETRICS_CONTENT_TYPE;
 
-		const promises = this.getMetricsAsArray().map(metric => {
-			if (isOpenMetrics && metric.type === 'counter') {
-				metric.name = standardizeCounterName(metric.name);
-			}
-			return this.getMetricsAsString(metric);
-		});
+		const promises = this.getMetricsAsArray().map(metric =>
+			this.getMetricsAsString(metric),
+		);
 
 		const resolves = await Promise.all(promises);
 
@@ -220,12 +231,15 @@ class Registry {
 		return this._contentType;
 	}
 
-	setContentType(metricsContentType) {
+	setContentType(metricsContentType, options = {}) {
 		if (
 			metricsContentType === Registry.OPENMETRICS_CONTENT_TYPE ||
 			metricsContentType === Registry.PROMETHEUS_CONTENT_TYPE
 		) {
 			this._contentType = metricsContentType;
+			this._counterWithoutTotalSuffix = validateCounterWithoutTotalSuffix(
+				options.counterWithoutTotalSuffix,
+			);
 		} else {
 			throw new Error(`Content type ${metricsContentType} is unsupported`);
 		}
@@ -336,6 +350,18 @@ function escapeString(str) {
 }
 function standardizeCounterName(name) {
 	return name.replace(/_total$/, '');
+}
+
+const COUNTER_WITHOUT_TOTAL_SUFFIX_MODES = ['append', 'unknown'];
+function validateCounterWithoutTotalSuffix(mode = 'append') {
+	if (!COUNTER_WITHOUT_TOTAL_SUFFIX_MODES.includes(mode)) {
+		throw new TypeError(
+			`counterWithoutTotalSuffix must be one of ${COUNTER_WITHOUT_TOTAL_SUFFIX_MODES.join(
+				', ',
+			)}, got ${mode}`,
+		);
+	}
+	return mode;
 }
 
 module.exports = Registry;

--- a/test/registerTest.js
+++ b/test/registerTest.js
@@ -33,6 +33,30 @@ describe('Register', () => {
 		}).toThrow(expectedContentTypeErrStr);
 	});
 
+	it.each([
+		[
+			'setContentType',
+			reg =>
+				reg.setContentType(Registry.OPENMETRICS_CONTENT_TYPE, {
+					counterWithoutTotalSuffix: 'bogus',
+				}),
+		],
+		[
+			'the constructor',
+			() =>
+				new Registry(Registry.OPENMETRICS_CONTENT_TYPE, {
+					counterWithoutTotalSuffix: 'bogus',
+				}),
+		],
+	])(
+		'should throw if given an unsupported counterWithoutTotalSuffix via %s',
+		(tag, act) => {
+			expect(() => act(register)).toThrow(
+				'counterWithoutTotalSuffix must be one of append, unknown, got bogus',
+			);
+		},
+	);
+
 	describe.each([
 		['Prometheus', Registry.PROMETHEUS_CONTENT_TYPE],
 		['OpenMetrics', Registry.OPENMETRICS_CONTENT_TYPE],
@@ -79,6 +103,37 @@ describe('Register', () => {
 				}
 			});
 		});
+
+		if (regType === Registry.OPENMETRICS_CONTENT_TYPE) {
+			describe('with counterWithoutTotalSuffix set to unknown', () => {
+				beforeEach(() => {
+					register.setContentType(regType, {
+						counterWithoutTotalSuffix: 'unknown',
+					});
+				});
+
+				it.each([
+					[
+						'test_metric',
+						'# TYPE test_metric unknown',
+						'test_metric{label="hello",code="303"} 12',
+					],
+					[
+						'test_metric_total',
+						'# TYPE test_metric counter',
+						'test_metric_total{label="hello",code="303"} 12',
+					],
+				])(
+					'keeps a counter named %s stable on the wire',
+					async (name, expectedType, expectedSample) => {
+						register.registerMetric(getMetric(name));
+						const output = (await register.metrics()).split('\n');
+						expect(output[1]).toEqual(expectedType);
+						expect(output[2]).toEqual(expectedSample);
+					},
+				);
+			});
+		}
 
 		it('should throw on more than one metric', () => {
 			register.registerMetric(getMetric());


### PR DESCRIPTION
TL;DR: add option to not break user's dashboards/arlerts when switching to OpenMetrics 1.0. At the price of demoting metric type of counters to "unknown" in metadata, but not adding `_total` suffix. Aligns with client_golang, forward compatible with OpenMetrics 2.0 which does not require suffix, just [encourages](https://prometheus.io/docs/specs/om/open_metrics_spec_2_0/#counter) it.

## Summary
- OpenMetrics requires Counter samples to carry a `_total` suffix. Today, switching a registry to `OPENMETRICS_CONTENT_TYPE` silently renames any Counter whose name doesn't already end in `_total` (e.g. `foo` becomes `foo_total` on the wire), which is a breaking change for consumers who scrape by name across the format switch.
- Adds an opt-in `counterWithoutTotalSuffix: 'unknown'` option to `Registry.setContentType()` and the `Registry` constructor. When set, such Counters keep their original name and are reported with type `unknown` instead of being renamed. Default remains `'append'` (today's behavior), so this is fully backwards compatible.
- As a side effect, removes a latent bug where `Registry.metrics()` permanently mutated the registered Counter's `.name` field in place; the naming decision is now computed locally per render.

## Test plan
- [x] `npm test` (596/596 passing)
- [x] `npm run lint`
- [x] `npx prettier --check .`
- [x] Added table-driven cases to `test/registerTest.js` covering the new option (valid/invalid mode, counter with/without pre-existing `_total` suffix)

Signed-off-by: György Krajcsovits <gyorgy.krajcsovits@grafana.com>