### PR TITLE
chore(deps-dev): upgrade prettier to 3.9.6 and lint-staged to 16.2.7

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,8 +29,7 @@ export type PrometheusContentType =
 	`${PrometheusMIME}; version=${PrometheusMetricsVersion}; charset=${Charset}`;
 
 export type RegistryContentType =
-	| PrometheusContentType
-	| OpenMetricsContentType;
+	PrometheusContentType | OpenMetricsContentType;
 
 /**
  * Container for all registered metrics
@@ -295,10 +294,7 @@ type NoLabelNameType = never;
  * General metric type
  */
 export type Metric<T extends string = NoLabelNameType> =
-	| Counter<T>
-	| Gauge<T>
-	| Summary<T>
-	| Histogram<T>;
+	Counter<T> | Gauge<T> | Summary<T> | Histogram<T>;
 
 /**
  * Aggregation methods, used for aggregating metrics in a Node.js cluster.
@@ -345,8 +341,7 @@ interface MetricConfiguration<T extends string> {
 	help: string;
 	labelNames?: T[] | readonly T[];
 	registers?: (
-		| Registry<PrometheusContentType>
-		| Registry<OpenMetricsContentType>
+		Registry<PrometheusContentType> | Registry<OpenMetricsContentType>
 	)[];
 	aggregator?: Aggregator;
 	collect?: CollectFunction<any>;

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
 		"globals": "^16.2.0",
 		"husky": "^9.0.0",
 		"jest": "^30.0.2",
-		"lint-staged": "^15.5.2",
+		"lint-staged": "^16.2.7",
 		"nock": "^13.0.5",
-		"prettier": "3.7.0",
+		"prettier": "^3.9.6",
 		"typescript": "^5.0.4",
 		"typescript-eslint": "^8.35.0"
 	},


### PR DESCRIPTION
## What

Land the two pending dev-dependency upgrades together and fix the formatting drift they expose:

- `prettier` 3.7.0 → 3.9.6
- `lint-staged` 15.5.2 → 16.2.7
- `index.d.ts`: accept the 3.9.6 formatting for three union types (they now fit on one line)

## Why

Both dependabot PRs were stuck: #733 (prettier) failed `Run Checks` because 3.9.6 reformats three union types in `index.d.ts`, and #730 (lint-staged) was failing the changelog check. Doing the two upgrades together means the prettier-driven reformat lands with the prettier bump in one PR, so `main` stays green at every step. lint-staged 16.2.7 keeps working with the existing `package.json` config unchanged.

## Testing

Run locally against Node v24:

- `npm run lint` — clean
- `npm run check-prettier` — "All matched files use Prettier code style!"
- `npm run compile-typescript` — clean
- `npm run test-unit` — 30 suites, 594 tests, all passing
- `npx lint-staged` — smoke-tested with staged JS/TS/JSON files: tasks ran and applied without config changes

This mirrors the CI `Run Checks` step (`npm run lint && npm run check-prettier && npm run compile-typescript`).
