### PR TITLE
chore: update prettier and lint-staged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Update Prettier and lint-staged
 - Organized default metrics
 - perf: Histogram rendering builds its export list straight from the store iterator instead of an intermediate array. Faster at high series counts on Node 24 and 26, can be slightly slower on Node 22
 - fix: Correct content type exported for cluster and worker mode.

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,8 +29,7 @@ export type PrometheusContentType =
 	`${PrometheusMIME}; version=${PrometheusMetricsVersion}; charset=${Charset}`;
 
 export type RegistryContentType =
-	| PrometheusContentType
-	| OpenMetricsContentType;
+	PrometheusContentType | OpenMetricsContentType;
 
 /**
  * Container for all registered metrics
@@ -295,10 +294,7 @@ type NoLabelNameType = never;
  * General metric type
  */
 export type Metric<T extends string = NoLabelNameType> =
-	| Counter<T>
-	| Gauge<T>
-	| Summary<T>
-	| Histogram<T>;
+	Counter<T> | Gauge<T> | Summary<T> | Histogram<T>;
 
 /**
  * Aggregation methods, used for aggregating metrics in a Node.js cluster.
@@ -345,8 +341,7 @@ interface MetricConfiguration<T extends string> {
 	help: string;
 	labelNames?: T[] | readonly T[];
 	registers?: (
-		| Registry<PrometheusContentType>
-		| Registry<OpenMetricsContentType>
+		Registry<PrometheusContentType> | Registry<OpenMetricsContentType>
 	)[];
 	aggregator?: Aggregator;
 	collect?: CollectFunction<any>;

--- a/package.json
+++ b/package.json
@@ -45,9 +45,9 @@
 		"globals": "^16.2.0",
 		"husky": "^9.0.0",
 		"jest": "^30.0.2",
-		"lint-staged": "^15.5.2",
+		"lint-staged": "^16.2.7",
 		"nock": "^13.0.5",
-		"prettier": "3.7.0",
+		"prettier": "3.9.6",
 		"typescript": "^5.0.4",
 		"typescript-eslint": "^8.35.0"
 	},


### PR DESCRIPTION
Updates Prettier to 3.9.6 and lint-staged to 16.2.7, then applies Prettier's resulting declaration formatting to `index.d.ts`. The changelog is updated as required.

Closes #831
