### PR TITLE
perf: remove core metric fallback truthiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - perf: Histogram rendering builds its export list straight from the store iterator instead of an intermediate array. Faster at high series counts on Node 24 and 26, can be slightly slower on Node 22
 - fix: Correct content type exported for cluster and worker mode.
 - perf: Remove truthy conditionals from default metric collectors
+- perf: Remove object and array fallback truthiness from core metric paths
 
 ### Added
 

--- a/lib/counter.js
+++ b/lib/counter.js
@@ -124,14 +124,14 @@ class Counter extends Metric {
 	}
 
 	labels(...args) {
-		const labels = getLabels(this.labelNames, args) || {};
+		const labels = getLabels(this.labelNames, args) ?? {};
 		return {
 			inc: this.inc.bind(this, labels),
 		};
 	}
 
 	remove(...args) {
-		const labels = getLabels(this.labelNames, args) || {};
+		const labels = getLabels(this.labelNames, args) ?? {};
 		this.store.validate(labels); //TODO: this isn't really necessary is it?
 		this.store.remove(labels);
 	}

--- a/lib/histogram.js
+++ b/lib/histogram.js
@@ -82,7 +82,7 @@ class Histogram extends Metric {
 	 * @returns {void}
 	 */
 	observeWithoutExemplar(labels, value) {
-		observe(this, labels === 0 ? 0 : labels || {}, value);
+		observe(this, labels === 0 ? 0 : (labels ?? {}), value);
 	}
 
 	observeWithExemplar({
@@ -90,7 +90,7 @@ class Histogram extends Metric {
 		value,
 		exemplarLabels = this.defaultExemplarLabelSet,
 	} = {}) {
-		observe(this, labels === 0 ? 0 : labels || {}, value);
+		observe(this, labels === 0 ? 0 : (labels ?? {}), value);
 		this.updateExemplar(labels, value, exemplarLabels);
 	}
 

--- a/lib/metrics/helpers/processMetricsHelpers.js
+++ b/lib/metrics/helpers/processMetricsHelpers.js
@@ -36,7 +36,7 @@ function aggregateByObjectName(list) {
 function updateMetrics(gauge, data, labels) {
 	gauge.reset();
 	for (const key in data) {
-		gauge.set(Object.assign({ type: key }, labels || {}), data[key]);
+		gauge.set(Object.assign({ type: key }, labels ?? {}), data[key]);
 	}
 }
 

--- a/lib/registry.js
+++ b/lib/registry.js
@@ -78,7 +78,7 @@ class Registry {
 		const isOpenMetrics =
 			this.contentType === Registry.OPENMETRICS_CONTENT_TYPE;
 
-		for (const val of metric.values || []) {
+		for (const val of metric.values ?? []) {
 			const { metricName = name, labels = {}, sharedLabels } = val;
 			const seriesName =
 				isOpenMetrics && metric.type === 'counter'

--- a/lib/summary.js
+++ b/lib/summary.js
@@ -57,7 +57,7 @@ class Summary extends Metric {
 	 * @returns {void}
 	 */
 	observe(labels, value) {
-		observe.call(this, labels === 0 ? 0 : labels || {})(value);
+		observe.call(this, labels === 0 ? 0 : (labels ?? {}))(value);
 	}
 
 	async get() {

--- a/lib/util.js
+++ b/lib/util.js
@@ -56,7 +56,7 @@ exports.setValue = function setValue(hashMap, value, labels) {
 	const hash = hashObject(labels);
 	hashMap.set(hash, {
 		value: typeof value === 'number' ? value : 0,
-		labels: labels || {},
+		labels: labels ?? {},
 	});
 	return hashMap;
 };


### PR DESCRIPTION
## Summary

- replace remaining core metric object and array fallback truthiness checks with nullish coalescing
- cover Counter, Histogram, Summary, Registry, shared utility, and process metric helper paths
- keep the change separate from the default collector cleanup in #824

Closes part of #823.

## Verification

- npm run lint
- npm run check-prettier
- npm run compile-typescript
- npm run test-unit -- --coverage --no-cache --runInBand (30 suites, 594 tests, 34 snapshots)