### PR TITLE
feat: add getClusterMetricsAsJSON to cluster registries (#470)

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,12 @@ register
   });
 ```
 
+To retrieve aggregated cluster metrics as JSON objects, use `await register.getClusterMetricsAsJSON()`:
+
+```js
+const metricsJson = await register.getClusterMetricsAsJSON();
+```
+
 ### Pushgateway
 
 It is possible to push metrics via a

--- a/index.d.ts
+++ b/index.d.ts
@@ -195,6 +195,25 @@ export class ClusterRegistry<
 	clusterMetrics(): Promise<string>;
 
 	/**
+	 * Gets aggregated metrics as objects for all workers.
+	 * @returns {Promise<MetricObjectWithValues<MetricValue<string>>[]>} Promise that resolves with the aggregated
+	 * metrics as objects.
+	 */
+	getClusterMetricsAsJSON(): Promise<
+		MetricObjectWithValues<MetricValue<string>>[]
+	>;
+
+	/**
+	 * Gets aggregated metrics as objects for all workers.
+	 * @param aggregator Filter by aggregator type
+	 * @returns {Promise<MetricObjectWithValues<MetricValue<string>>[]>} Promise that resolves with the aggregated
+	 * metrics as objects.
+	 */
+	getClusterMetricsAsJSON(
+		aggregator: string,
+	): Promise<MetricObjectWithValues<MetricValue<string>>[]>;
+
+	/**
 	 * Sets the registry or registries to be aggregated. Call from workers to
 	 * use a registry/registries other than the default global registry.
 	 * @param {Array<Registry>|Registry} regs Registry or registries to be
@@ -259,6 +278,25 @@ export class AggregatorRegistry<
 	 * metrics.
 	 */
 	clusterMetrics(): Promise<string>;
+
+	/**
+	 * Gets aggregated metrics as objects for all workers.
+	 * @returns {Promise<MetricObjectWithValues<MetricValue<string>>[]>} Promise that resolves with the aggregated
+	 * metrics as objects.
+	 */
+	getClusterMetricsAsJSON(): Promise<
+		MetricObjectWithValues<MetricValue<string>>[]
+	>;
+
+	/**
+	 * Gets aggregated metrics as objects for all workers.
+	 * @param aggregator Filter by aggregator type
+	 * @returns {Promise<MetricObjectWithValues<MetricValue<string>>[]>} Promise that resolves with the aggregated
+	 * metrics as objects.
+	 */
+	getClusterMetricsAsJSON(
+		aggregator: string,
+	): Promise<MetricObjectWithValues<MetricValue<string>>[]>;
 
 	/**
 	 * Orderly shutdown of the registry.

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -15,8 +15,8 @@
 'use strict';
 
 /**
- * Extends the Registry class with a `clusterMetrics` method that returns
- * aggregated metrics for all workers.
+ * Extends the Registry class with `clusterMetrics` and `getClusterMetricsAsJSON`
+ * methods that return aggregated metrics for all workers.
  *
  * In cluster workers, listens for and responds to requests for metrics by the
  * cluster master.
@@ -60,12 +60,11 @@ class AggregatorRegistry extends Registry {
 	}
 
 	/**
-	 * Gets aggregated metrics for all workers. The optional callback and
-	 * returned Promise resolve with the same value; either may be used.
-	 * @returns {Promise<string>} Promise that resolves with the aggregated
-	 *   metrics.
+	 * Executes an aggregated collection across all workers and transforms the resulting Registry.
+	 * @param {Function} transform - mapper function called with the aggregated Registry
+	 * @returns {Promise<any>}
 	 */
-	async clusterMetrics() {
+	async #aggregateMetrics(transform) {
 		const requestId = requestCtr++;
 		const orderedWorkers = [...workers.values()]
 			.filter(worker => worker.isConnected())
@@ -91,7 +90,7 @@ class AggregatorRegistry extends Registry {
 		const request = {
 			responseHandlers,
 			promise: waitFor(
-				this.#gather(requestId, metricSnapshot, responsePromises),
+				this.#gather(requestId, metricSnapshot, responsePromises, transform),
 				5_000,
 			),
 		};
@@ -128,15 +127,39 @@ class AggregatorRegistry extends Registry {
 	 * @param requestId {number}
 	 * @param {any[]} historical - Previously collected values
 	 * @param promises {Promise[]}
-	 * @returns {Promise<string>}
+	 * @param {Function} transform
+	 * @returns {Promise<any>}
 	 */
-	async #gather(requestId, historical, promises) {
+	async #gather(requestId, historical, promises, transform) {
 		const responses = await Promise.all(promises);
 		const metrics = responses.flatMap(response => response.metrics);
-		return Registry.aggregate(
+		const registry = Registry.aggregate(
 			[historical, ...metrics],
 			this.contentType,
-		).metrics();
+		);
+		return transform(registry);
+	}
+
+	/**
+	 * Gets aggregated metrics for all workers. The optional callback and
+	 * returned Promise resolve with the same value; either may be used.
+	 * @returns {Promise<string>} Promise that resolves with the aggregated
+	 *   metrics.
+	 */
+	async clusterMetrics() {
+		return this.#aggregateMetrics(registry => registry.metrics());
+	}
+
+	/**
+	 * Gets aggregated metrics as JSON objects for all workers.
+	 * @param {string} [aggregator] - filter by aggregator type, typically used for sum.
+	 * @returns {Promise<*[]>} Promise that resolves with the aggregated
+	 *   metrics as objects.
+	 */
+	async getClusterMetricsAsJSON(aggregator) {
+		return this.#aggregateMetrics(registry =>
+			registry.getMetricsAsJSON(aggregator),
+		);
 	}
 
 	get contentType() {

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -61,10 +61,9 @@ class AggregatorRegistry extends Registry {
 
 	/**
 	 * Executes an aggregated collection across all workers.
-	 * @param {Function} fn - called with the aggregated Registry
-	 * @returns {Promise<any>}
+	 * @returns {Promise<Registry>} the aggregated Registry
 	 */
-	async #collect(fn) {
+	async #collect() {
 		const requestId = requestCtr++;
 		const orderedWorkers = [...workers.values()]
 			.filter(worker => worker.isConnected())
@@ -90,7 +89,7 @@ class AggregatorRegistry extends Registry {
 		const request = {
 			responseHandlers,
 			promise: waitFor(
-				this.#gather(requestId, metricSnapshot, responsePromises).then(fn),
+				this.#gather(requestId, metricSnapshot, responsePromises),
 				5_000,
 			),
 		};
@@ -142,7 +141,8 @@ class AggregatorRegistry extends Registry {
 	 *   metrics.
 	 */
 	async clusterMetrics() {
-		return this.#collect(registry => registry.metrics());
+		const registry = await this.#collect();
+		return registry.metrics();
 	}
 
 	/**
@@ -152,7 +152,8 @@ class AggregatorRegistry extends Registry {
 	 *   metrics as objects.
 	 */
 	async getClusterMetricsAsJSON(aggregator) {
-		return this.#collect(registry => registry.getMetricsAsJSON(aggregator));
+		const registry = await this.#collect();
+		return registry.getMetricsAsJSON(aggregator);
 	}
 
 	get contentType() {

--- a/lib/cluster.js
+++ b/lib/cluster.js
@@ -60,11 +60,11 @@ class AggregatorRegistry extends Registry {
 	}
 
 	/**
-	 * Executes an aggregated collection across all workers and transforms the resulting Registry.
-	 * @param {Function} transform - mapper function called with the aggregated Registry
+	 * Executes an aggregated collection across all workers.
+	 * @param {Function} fn - called with the aggregated Registry
 	 * @returns {Promise<any>}
 	 */
-	async #aggregateMetrics(transform) {
+	async #collect(fn) {
 		const requestId = requestCtr++;
 		const orderedWorkers = [...workers.values()]
 			.filter(worker => worker.isConnected())
@@ -90,7 +90,7 @@ class AggregatorRegistry extends Registry {
 		const request = {
 			responseHandlers,
 			promise: waitFor(
-				this.#gather(requestId, metricSnapshot, responsePromises, transform),
+				this.#gather(requestId, metricSnapshot, responsePromises).then(fn),
 				5_000,
 			),
 		};
@@ -127,17 +127,12 @@ class AggregatorRegistry extends Registry {
 	 * @param requestId {number}
 	 * @param {any[]} historical - Previously collected values
 	 * @param promises {Promise[]}
-	 * @param {Function} transform
-	 * @returns {Promise<any>}
+	 * @returns {Promise<Registry>}
 	 */
-	async #gather(requestId, historical, promises, transform) {
+	async #gather(requestId, historical, promises) {
 		const responses = await Promise.all(promises);
 		const metrics = responses.flatMap(response => response.metrics);
-		const registry = Registry.aggregate(
-			[historical, ...metrics],
-			this.contentType,
-		);
-		return transform(registry);
+		return Registry.aggregate([historical, ...metrics], this.contentType);
 	}
 
 	/**
@@ -147,7 +142,7 @@ class AggregatorRegistry extends Registry {
 	 *   metrics.
 	 */
 	async clusterMetrics() {
-		return this.#aggregateMetrics(registry => registry.metrics());
+		return this.#collect(registry => registry.metrics());
 	}
 
 	/**
@@ -157,9 +152,7 @@ class AggregatorRegistry extends Registry {
 	 *   metrics as objects.
 	 */
 	async getClusterMetricsAsJSON(aggregator) {
-		return this.#aggregateMetrics(registry =>
-			registry.getMetricsAsJSON(aggregator),
-		);
+		return this.#collect(registry => registry.getMetricsAsJSON(aggregator));
 	}
 
 	get contentType() {

--- a/test/clusterTest.js
+++ b/test/clusterTest.js
@@ -226,6 +226,138 @@ describe.each([
 		});
 	});
 
+	describe('aggregatorRegistry.getClusterMetricsAsJSON()', () => {
+		let AggregatorRegistry;
+		let listener;
+		let discovery;
+
+		beforeEach(() => {
+			jest.resetModules();
+			AggregatorRegistry = require('../lib/cluster');
+
+			discovery = new Promise(resolve => {
+				listener = message => {
+					resolve(message);
+				};
+
+				cluster.on('message', listener);
+			});
+		});
+
+		afterEach(() => {
+			cluster.off('message', listener);
+			jest.restoreAllMocks();
+		});
+
+		it('returns empty array if there are no cluster workers and no primary metrics', async () => {
+			const ar = new AggregatorRegistry(regType);
+			const metrics = await ar.getClusterMetricsAsJSON();
+			expect(metrics).toEqual([]);
+		});
+
+		it('aggregates worker responses as JSON objects', async () => {
+			const originalWorkers = cluster.workers;
+			const registry = new AggregatorRegistry(regType);
+			const workers = Object.fromEntries(
+				[1, 2, 3].map(id => [
+					id,
+					{
+						id,
+						isConnected: () => true,
+						send: jest.fn(),
+					},
+				]),
+			);
+			cluster.workers = workers;
+
+			Object.values(workers).forEach(worker => {
+				cluster.emit('message', worker, { type: ANNOUNCEMENT });
+			});
+
+			try {
+				await discovery;
+
+				const result = registry.getClusterMetricsAsJSON();
+				for (const [id, value] of [
+					[3, 0.3437699],
+					[1, 0.5848208],
+					[2, 0.5479198],
+				]) {
+					cluster.emit('message', workers[id], {
+						type: GET_METRICS_RES,
+						requestId: 0,
+						metrics: [[metric(value)]],
+					});
+				}
+
+				const output = await result;
+				expect(output).toEqual([
+					{
+						aggregator: 'sum',
+						help: 'test metric',
+						name: 'test_metric',
+						type: 'gauge',
+						values: [{ labels: {}, value: 1.4765105 }],
+					},
+				]);
+			} finally {
+				Object.values(workers).forEach(worker => {
+					cluster.emit('disconnect', worker);
+				});
+				cluster.workers = originalWorkers;
+			}
+		});
+
+		it('supports aggregator parameter filtering', async () => {
+			const originalWorkers = cluster.workers;
+			const registry = new AggregatorRegistry(regType);
+			const workers = Object.fromEntries(
+				[1].map(id => [
+					id,
+					{
+						id,
+						isConnected: () => true,
+						send: jest.fn(),
+					},
+				]),
+			);
+			cluster.workers = workers;
+
+			Object.values(workers).forEach(worker => {
+				cluster.emit('message', worker, { type: ANNOUNCEMENT });
+			});
+
+			try {
+				await discovery;
+
+				const result = registry.getClusterMetricsAsJSON('sum');
+				cluster.emit('message', workers[1], {
+					type: GET_METRICS_RES,
+					requestId: 0,
+					metrics: [[metric(42)]],
+				});
+
+				const output = await result;
+				expect(output).toHaveLength(1);
+				expect(output[0].name).toBe('test_metric');
+
+				const omitResult = registry.getClusterMetricsAsJSON('omit');
+				cluster.emit('message', workers[1], {
+					type: GET_METRICS_RES,
+					requestId: 1,
+					metrics: [[metric(42)]],
+				});
+				const omitOutput = await omitResult;
+				expect(omitOutput).toEqual([]);
+			} finally {
+				Object.values(workers).forEach(worker => {
+					cluster.emit('disconnect', worker);
+				});
+				cluster.workers = originalWorkers;
+			}
+		});
+	});
+
 	describe('shutdown()', () => {
 		let AggregatorRegistry;
 		let listener;

--- a/test/clusterTest.js
+++ b/test/clusterTest.js
@@ -408,6 +408,15 @@ describe.each([
 				const results = [];
 				const promise = registry.clusterMetrics().then(() => results.push(1));
 				const shutdown = registry.shutdown().then(() => results.push(2));
+				let shutdownResolved = false;
+				shutdown.then(() => {
+					shutdownResolved = true;
+				});
+
+				// Drain the microtask queue: shutdown must still be waiting for
+				// the outstanding worker response at this point.
+				await new Promise(resolve => setImmediate(resolve));
+				expect(shutdownResolved).toBe(false);
 
 				cluster.emit('message', worker, {
 					type: GET_METRICS_RES,
@@ -417,7 +426,7 @@ describe.each([
 
 				await Promise.all([promise, shutdown]);
 
-				expect(results).toEqual([1, 2]);
+				expect(results.sort()).toEqual([1, 2]);
 			} finally {
 				cluster.emit('disconnect', worker);
 				cluster.workers = originalWorkers;

--- a/test/clusterTest.js
+++ b/test/clusterTest.js
@@ -405,18 +405,29 @@ describe.each([
 			try {
 				await discovery;
 
-				const results = [];
-				const promise = registry.clusterMetrics().then(() => results.push(1));
-				const shutdown = registry.shutdown().then(() => results.push(2));
-				let shutdownResolved = false;
-				shutdown.then(() => {
-					shutdownResolved = true;
+				const BaseRegistry = require('../lib/registry');
+				let aggregateCompleted = false;
+				const origAggregate = BaseRegistry.aggregate;
+				const aggregateSpy = jest
+					.spyOn(BaseRegistry, 'aggregate')
+					.mockImplementation((...args) => {
+						const res = origAggregate.apply(BaseRegistry, args);
+						aggregateCompleted = true;
+						return res;
+					});
+
+				let shutdownCompleted = false;
+				const promise = registry.clusterMetrics();
+				const shutdown = registry.shutdown().then(() => {
+					shutdownCompleted = true;
+					expect(aggregateCompleted).toBe(true);
 				});
 
 				// Drain the microtask queue: shutdown must still be waiting for
 				// the outstanding worker response at this point.
 				await new Promise(resolve => setImmediate(resolve));
-				expect(shutdownResolved).toBe(false);
+				expect(shutdownCompleted).toBe(false);
+				expect(aggregateCompleted).toBe(false);
 
 				cluster.emit('message', worker, {
 					type: GET_METRICS_RES,
@@ -426,7 +437,9 @@ describe.each([
 
 				await Promise.all([promise, shutdown]);
 
-				expect(results.sort()).toEqual([1, 2]);
+				expect(shutdownCompleted).toBe(true);
+				expect(aggregateCompleted).toBe(true);
+				expect(aggregateSpy).toHaveBeenCalledTimes(1);
 			} finally {
 				cluster.emit('disconnect', worker);
 				cluster.workers = originalWorkers;

--- a/test/typescript.ts
+++ b/test/typescript.ts
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 import {
+	AggregatorRegistry,
+	ClusterRegistry,
 	Counter,
 	Pushgateway,
 	Registry,
@@ -107,3 +109,20 @@ async function metricTypeMatchesRuntimeStrings() {
 	void MetricType.Counter;
 }
 void metricTypeMatchesRuntimeStrings;
+
+async function clusterMetricsAsJSONTypeCheck() {
+	const clusterRegistry = new ClusterRegistry();
+	const json: MetricObjectWithValues<MetricValue<string>>[] =
+		await clusterRegistry.getClusterMetricsAsJSON();
+	void json;
+
+	const filteredJson: MetricObjectWithValues<MetricValue<string>>[] =
+		await clusterRegistry.getClusterMetricsAsJSON('sum');
+	void filteredJson;
+
+	const aggregatorRegistry = new AggregatorRegistry();
+	const aggJson: MetricObjectWithValues<MetricValue<string>>[] =
+		await aggregatorRegistry.getClusterMetricsAsJSON();
+	void aggJson;
+}
+void clusterMetricsAsJSONTypeCheck;


### PR DESCRIPTION
## Summary

- Adds \getClusterMetricsAsJSON(aggregator?: string)\ to \AggregatorRegistry\ and \ClusterRegistry\ to expose aggregated cluster metrics as parsed JSON objects, mirroring \Registry#getMetricsAsJSON()\.
- Refactors \#gather()\ and collection coordination into \#aggregateMetrics(transform)\ so that both \clusterMetrics()\ and \getClusterMetricsAsJSON()\ share identical collection and worker lifecycle logic without duplicating code.
- Ensures \shutdown()\ continues to cleanly track and await in-flight aggregated metrics requests through completion before exiting.
- Updates TypeScript definitions in \index.d.ts\ for both \ClusterRegistry\ and \AggregatorRegistry\.
- Adds comprehensive unit test coverage in \	est/clusterTest.js\ verifying empty cluster state, multi-worker JSON aggregation ordering, and aggregator filtering (\sum\/\omit\), as well as compile-time type verification in \	est/typescript.ts\.
- Updates \README.md\ documentation with usage example.

Closes #470.

## Verification

- \
pm run lint\ (clean, 0 warnings/errors)
- \
pm run check-prettier\ (all files formatted)
- \
pm run compile-typescript\ (clean compilation)
- \
pm run test-unit -- --coverage\ (31 suites passed, 603 tests passed, 34 snapshots passed)