### PR TITLE
fix: fill TimeWindowQuantiles with independent TDigest instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - perf: Remove truthy conditionals from default metric collectors
 - fix: Preserve zero-valued Counter exemplars
 - perf: Remove object and array fallback truthiness from core metric paths
+- fix: use independent TDigest stores in TimeWindowQuantiles
 
 ### Added
 

--- a/lib/timeWindowQuantiles.js
+++ b/lib/timeWindowQuantiles.js
@@ -23,7 +23,10 @@ class TimeWindowQuantiles {
 
 		this.shouldRotate = maxAgeSeconds && ageBuckets;
 
-		this.ringBuffer = Array(ageBuckets).fill(new TDigest());
+		this.ringBuffer = Array.from(
+			{ length: ageBuckets || 1 },
+			() => new TDigest(),
+		);
 		this.currentBuffer = 0;
 
 		this.lastRotateTimestampMillis = Date.now();

--- a/test/timeWindowQuantilesTest.js
+++ b/test/timeWindowQuantilesTest.js
@@ -88,5 +88,13 @@ describe('timeWindowQuantiles', () => {
 				expect(td.centroids.size).toEqual(0);
 			});
 		});
+
+		it('should keep buckets independent during rotation', () => {
+			instance.push(0);
+			jest.advanceTimersByTime(1001);
+			instance.push(100);
+
+			expect(instance.percentile(0.5)).toEqual(50);
+		});
 	});
 });


### PR DESCRIPTION
Current option stores the same TDigest reference for each item in the ringBuffer. This results in skewed results after rotation.